### PR TITLE
Use ATR values directly in alert builder

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,7 +85,7 @@ async function runOnceForAsset(asset) {
                     lastClose: snapshot.kpis.price,
                     var24h: snapshot.kpis.var24h,
                     closes: close, highs: high, lows: low, volumes: vol,
-                    atrSeries: atr.map(x => x.atr),
+                    atrSeries: atr,
                     upperBB: bb.upper, lowerBB: bb.lower,
                     sarSeries: undefined, trendSeries: undefined, heuristicSeries: undefined,
                     vwapSeries: undefined, ema9: undefined, ema21: undefined, stochasticK: undefined, stochasticD: undefined, willrSeries: undefined, cciSeries: undefined, obvSeries: undefined


### PR DESCRIPTION
## Summary
- pass ATR values straight to `buildAlerts` instead of mapping `.atr`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:chart`


------
https://chatgpt.com/codex/tasks/task_e_68c2072e7cd48326a497eb3007ef0dcb