### PR TITLE
feat: add debug flag and conditional logging

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -24,6 +24,7 @@ export const CFG = {
     enableAlerts: process.env.ENABLE_ALERTS === undefined || process.env.ENABLE_ALERTS === 'true',
     enableAnalysis: process.env.ENABLE_ANALYSIS === undefined || process.env.ENABLE_ANALYSIS === 'true',
     enableReports: process.env.ENABLE_REPORTS === undefined || process.env.ENABLE_REPORTS === 'true',
+    debug: process.env.DEBUG === 'true',
 };
 
 export const config = {

--- a/src/data/binance.js
+++ b/src/data/binance.js
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { fetchWithRetry } from "../utils.js";
+import { CFG } from "../config.js";
 
 const BASE = "https://api.binance.com/api/v3/klines";
 const CANDLES = 200; // solicitamos pelo menos 200 barras
@@ -8,7 +9,9 @@ export async function fetchOHLCV(symbol, interval) {
     console.log(`Fetching OHLCV for ${symbol} ${interval}`);
     const url = `${BASE}?symbol=${symbol}&interval=${interval}&limit=${CANDLES}`;
     const { data } = await fetchWithRetry(() => axios.get(url));
-    console.log("OHLCV data:");
+    if (CFG.debug) {
+        console.log("OHLCV data:");
+    }
     return data.map(c => ({
         t: new Date(c[0]),
         o: +c[1], h: +c[2], l: +c[3], c: +c[4],
@@ -20,6 +23,8 @@ export async function fetchDailyCloses(symbol, days = 32) {
     console.log(`Fetching daily closes for ${symbol} last ${days} days`);
     const url = `${BASE}?symbol=${symbol}&interval=1d&limit=${days}`;
     const { data } = await fetchWithRetry(() => axios.get(url));
-    console.log("Daily closes data:", data);
+    if (CFG.debug) {
+        console.log("Daily closes data:", data);
+    }
     return data.map(c => ({ t: new Date(c[0]), c: +c[4], v: +c[5] }));
 }


### PR DESCRIPTION
## Summary
- add `debug` flag in configuration to toggle verbose logs
- log OHLCV and daily closes data only when `CFG.debug` is enabled

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:chart`


------
https://chatgpt.com/codex/tasks/task_e_68c20e2a9c7c8326aae35327c49ed36f