### PR TITLE
feat: add config validation

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,5 @@
 import 'dotenv/config';
+import { ASSETS } from './assets.js';
 export const CFG = {
     webhook: process.env.DISCORD_WEBHOOK_URL,
     webhookAlerts: process.env.DISCORD_WEBHOOK_ALERTS_URL,
@@ -31,3 +32,35 @@ export const config = {
     newsApiKey: process.env.NEWS_API_KEY,
     serpapiApiKey: process.env.SERPAPI_API_KEY,
 };
+
+export function validateConfig() {
+    const missing = [];
+
+    if (!process.env.DISCORD_WEBHOOK_URL) {
+        missing.push('DISCORD_WEBHOOK_URL');
+    }
+
+    for (const { key, binance } of ASSETS) {
+        if (!binance) {
+            missing.push(`BINANCE_SYMBOL_${key}`);
+        }
+    }
+
+    const apiKeys = ['OPENROUTER_API_KEY', 'NEWS_API_KEY', 'SERPAPI_API_KEY'];
+    for (const key of apiKeys) {
+        if (!process.env[key]) {
+            missing.push(key);
+        }
+    }
+
+    if (missing.length > 0) {
+        const message = `Missing required environment variables: ${missing.join(', ')}`;
+        if (process.env.NODE_ENV === 'production') {
+            throw new Error(message);
+        } else {
+            console.warn(message);
+        }
+    }
+}
+
+validateConfig();


### PR DESCRIPTION
## Summary
- add `validateConfig()` to ensure required environment variables are set
- warn or throw when critical Discord, Binance, or API key values are missing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run test:chart`


------
https://chatgpt.com/codex/tasks/task_e_68c20ee14c548326afa1b6d4d0d94d8c