### PR TITLE
feat: make concurrency configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,10 @@ TZ=Europe/Lisbon
 # ALERT_DEDUP_MINUTES: janela de deduplicação em minutos
 ALERT_DEDUP_MINUTES=60
 
+## Máximo de concorrência
+# MAX_CONCURRENCY: número máximo de análises simultâneas (padrão: núcleos da CPU)
+MAX_CONCURRENCY=4
+
 ## OpenRouter API
 # OPENROUTER_API_KEY: chave de acesso ao OpenRouter
 OPENROUTER_API_KEY=your-openrouter-key

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ This project posts crypto analysis, charts and alerts to Discord.
 
 The `.env.example` file documents each available variable with a purpose and example value.
 
+Key variables:
+
+- `MAX_CONCURRENCY` – optional limit for parallel analyses (defaults to the number of CPU cores).
+
 ## Technical Articles
 
 - [Getting started with Discord webhooks](https://support.discord.com/hc/en-us/articles/228383668)

--- a/src/config.js
+++ b/src/config.js
@@ -30,6 +30,7 @@ export const CFG = {
     accountEquity: parseFloat(process.env.ACCOUNT_EQUITY || '0'),
     riskPerTrade: parseFloat(process.env.RISK_PER_TRADE || '0.01'),
     alertDedupMinutes: parseFloat(process.env.ALERT_DEDUP_MINUTES || '60'),
+    maxConcurrency: process.env.MAX_CONCURRENCY ? parseInt(process.env.MAX_CONCURRENCY, 10) : undefined,
 };
 
 export const config = {

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ import { runAgent } from "./ai.js";
 import { getSignature, updateSignature, saveStore } from "./store.js";
 import { fetchEconomicEvents } from "./data/economic.js";
 import { logger, withContext, createContext } from "./logger.js";
-import pLimit from "./limit.js";
+import pLimit, { calcConcurrency } from "./limit.js";
 import { buildHash, shouldSend } from "./alertCache.js";
 import { register } from "./metrics.js";
 import { notifyOps } from "./monitor.js";
@@ -154,7 +154,7 @@ async function runOnceForAsset(asset) {
 }
 
 async function runAll() {
-    const limit = pLimit(3);
+    const limit = pLimit(calcConcurrency());
     await Promise.all(
         ASSETS.map(asset => limit(() => runOnceForAsset(asset)))
     );

--- a/src/limit.js
+++ b/src/limit.js
@@ -1,3 +1,11 @@
+import os from 'os';
+import { CFG } from './config.js';
+
+export function calcConcurrency() {
+    const max = Number(CFG.maxConcurrency);
+    return Number.isInteger(max) && max > 0 ? max : os.cpus().length;
+}
+
 export default function pLimit(concurrency) {
     if (concurrency < 1) {
         throw new TypeError('Expected `concurrency` to be a number greater than 0');


### PR DESCRIPTION
## Summary
- derive optimal concurrency from `MAX_CONCURRENCY` or CPU cores
- use dynamic concurrency for asset processing
- document `MAX_CONCURRENCY` env var

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c541de78548326a0122ec36187301f