### PR TITLE
Add helper for rotating file transport

### DIFF
--- a/src/logger-transport.cjs
+++ b/src/logger-transport.cjs
@@ -1,0 +1,20 @@
+const rotatingFileStreamFactory = require('pino-rotating-file-stream');
+const factory = typeof rotatingFileStreamFactory === 'function'
+  ? rotatingFileStreamFactory
+  : rotatingFileStreamFactory.default;
+
+module.exports = function loggerTransport(options) {
+  const sanitized = options && typeof options === 'object'
+    ? { ...options }
+    : {};
+
+  if (Object.prototype.hasOwnProperty.call(sanitized, '$context')) {
+    delete sanitized.$context;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(sanitized, 'pinoWillSendConfig')) {
+    delete sanitized.pinoWillSendConfig;
+  }
+
+  return factory(sanitized);
+};

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,14 +1,17 @@
 import pino from 'pino';
 import { randomUUID } from 'crypto';
 import fs from 'fs';
+import { fileURLToPath } from 'url';
 
 const logsDir = 'logs';
 if (!fs.existsSync(logsDir)) {
   fs.mkdirSync(logsDir, { recursive: true });
 }
 
+const transportTarget = fileURLToPath(new URL('./logger-transport.cjs', import.meta.url));
+
 const transport = process.env.NODE_ENV === 'test' ? undefined : {
-  target: 'pino-rotating-file-stream',
+  target: transportTarget,
   options: {
     path: logsDir,
     filename: 'app-%DATE%.log',


### PR DESCRIPTION
## Summary
- add a CommonJS helper that wraps pino-rotating-file-stream and strips metadata before delegating to the original factory
- update the logger transport configuration to reference the helper while preserving rotation options outside of test runs

## Testing
- node src/index.js --once *(fails: external Binance API calls exceed redirect limits in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d070e88b5483269b8cc9714deeca75