### PR TITLE
Handle concurrency limits from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The `.env.example` file documents each available variable with a purpose and exa
 
 Key variables:
 
-- `MAX_CONCURRENCY` – optional limit for parallel analyses (defaults to the number of CPU cores).
+- `MAX_CONCURRENCY` – optional limit for parallel analyses. When omitted or invalid the bot automatically matches the number of available CPU cores; set to `1` to force sequential processing.
 - `BINANCE_CACHE_TTL_MINUTES` – cache duration for Binance price data in minutes (defaults to 10 minutes).
 
 ## Technical Articles

--- a/src/limit.js
+++ b/src/limit.js
@@ -3,7 +3,20 @@ import { CFG } from './config.js';
 
 export function calcConcurrency() {
     const max = Number(CFG.maxConcurrency);
-    return Number.isInteger(max) && max > 0 ? max : os.cpus().length;
+    if (Number.isInteger(max) && max > 0) {
+        return max;
+    }
+
+    try {
+        const cpus = os.cpus();
+        if (Array.isArray(cpus) && cpus.length > 0) {
+            return cpus.length;
+        }
+    } catch (_) {
+        // Fall through to default below when os.cpus() is unavailable.
+    }
+
+    return 1;
 }
 
 export default function pLimit(concurrency) {


### PR DESCRIPTION
## Summary
- make calcConcurrency() honor MAX_CONCURRENCY when valid and fall back to CPU count with a safe default
- document the MAX_CONCURRENCY environment variable behavior in the README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d109f2210c8326a5bb4f6aeda2b484