### PR TITLE
Add weekly performance summary to reports

### DIFF
--- a/src/perf.js
+++ b/src/perf.js
@@ -12,13 +12,14 @@ export function recordPerf(name, ms) {
 }
 
 export function reportWeeklyPerf() {
-  const averages = {};
+  const summary = {};
   for (const [name, arr] of Object.entries(stats)) {
-    const avg = arr.length ? arr.reduce((a, b) => a + b, 0) / arr.length : 0;
-    averages[name] = avg;
+    const count = arr.length;
+    const avg = count ? arr.reduce((a, b) => a + b, 0) / count : 0;
+    summary[name] = { avg, count };
     stats[name] = [];
   }
   const log = withContext(logger);
-  log.info({ fn: 'weeklyPerf', averages }, 'Weekly performance averages (ms)');
-  return averages;
+  log.debug({ fn: 'weeklyPerf', summary }, 'Weekly performance averages (ms)');
+  return summary;
 }


### PR DESCRIPTION
## Summary
- log weekly performance aggregates at debug level and capture call counts for each instrumented function
- include runtime averages in the weekly analysis report when data is available

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d10c554be48326952761105c1b1a6a