### PR TITLE
Expose Binance cache TTL configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The `.env.example` file documents each available variable with a purpose and exa
 Key variables:
 
 - `MAX_CONCURRENCY` – optional limit for parallel analyses. When omitted or invalid the bot automatically matches the number of available CPU cores; set to `1` to force sequential processing.
-- `BINANCE_CACHE_TTL_MINUTES` – cache duration for Binance price data in minutes (defaults to 10 minutes).
+- `BINANCE_CACHE_TTL_MINUTES` – cache duration for Binance price data in minutes (defaults to 10 minutes when unset or invalid). This value is available at runtime as `CFG.binanceCacheTTL` and controls the TTL of the shared Binance `LRUCache` instance.
 
 ## Technical Articles
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,12 @@
 import 'dotenv/config';
 import { ASSETS } from './assets.js';
 import { logger, withContext } from './logger.js';
+const DEFAULT_BINANCE_CACHE_TTL_MINUTES = 10;
+const parsedBinanceCacheTTL = Number.parseFloat(process.env.BINANCE_CACHE_TTL_MINUTES ?? '');
+const binanceCacheTTL = Number.isFinite(parsedBinanceCacheTTL) && parsedBinanceCacheTTL > 0
+    ? parsedBinanceCacheTTL
+    : DEFAULT_BINANCE_CACHE_TTL_MINUTES;
+
 export const CFG = {
     webhook: process.env.DISCORD_WEBHOOK_URL,
     webhookAlerts: process.env.DISCORD_WEBHOOK_ALERTS_URL,
@@ -30,7 +36,7 @@ export const CFG = {
     accountEquity: parseFloat(process.env.ACCOUNT_EQUITY || '0'),
     riskPerTrade: parseFloat(process.env.RISK_PER_TRADE || '0.01'),
     alertDedupMinutes: parseFloat(process.env.ALERT_DEDUP_MINUTES || '60'),
-    binanceCacheTTL: parseFloat(process.env.BINANCE_CACHE_TTL_MINUTES || '10'),
+    binanceCacheTTL,
     maxConcurrency: process.env.MAX_CONCURRENCY ? parseInt(process.env.MAX_CONCURRENCY, 10) : undefined,
 };
 

--- a/src/data/binance.js
+++ b/src/data/binance.js
@@ -11,9 +11,10 @@ const CANDLES = 200; // solicitamos pelo menos 200 barras
 const RATE_LIMIT_MS = 200;
 let lastCall = 0;
 // Cache for OHLCV and daily close requests
+const CACHE_TTL_MS = CFG.binanceCacheTTL * 60 * 1000;
 const cache = new LRUCache({
     max: 500,
-    ttl: CFG.binanceCacheTTL * 60 * 1000,
+    ttl: CACHE_TTL_MS,
 });
 
 async function rateLimit() {


### PR DESCRIPTION
## Summary
- sanitize the Binance cache TTL when building CFG so the value is always a positive number and expose it for reuse
- use the resolved configuration value when instantiating the shared Binance LRU cache
- document the new BINANCE_CACHE_TTL_MINUTES behaviour and runtime exposure in the README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d10d3d5df48326b5c267b4342ee3cc