### PR TITLE
Configure Vitest coverage reporting

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "node src/index.js",
     "once": "node src/index.js --once",
     "test:chart": "node tests/render-chart.js",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@jvddavid/pino-rotating-file": "^1.0.7",

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    coverage: {
+      reporter: ['text', 'lcov'],
+      thresholds: {
+        statements: 70,
+        branches: 70,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add a Vitest configuration file to enable text and lcov coverage reports with initial 70% statement and branch thresholds
- extend the package scripts with a test:coverage command that collects coverage data

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d1539f60a483269003d5f831aa27d8