### PR TITLE
Add ADX/Keltner metrics to reports and alerts

### DIFF
--- a/src/alerts.js
+++ b/src/alerts.js
@@ -5,13 +5,27 @@ import { performance } from 'node:perf_hooks';
 import { logger, withContext } from './logger.js';
 import { recordPerf } from './perf.js';
 
+const DEFAULT_THRESHOLDS = {
+    rsi: { overbought: 70, oversold: 30, midpoint: 50 },
+    adx: { strongTrend: 25 },
+    volumeSpike: 2,
+    atrSpike: 1.5,
+    stochastic: { overbought: 80, oversold: 20 },
+    williamsR: { overbought: -20, oversold: -80 },
+    cci: { overbought: 100, oversold: -100 },
+    heuristic: { high: 80, low: 20 },
+    obv: { delta: 0.05 }
+};
+
 export function buildAlerts({
-    rsiSeries, macdObj, bbWidth, ma20, ma50, ma200, lastClose, var24h, closes, highs, lows, volumes, atrSeries, upperBB, lowerBB, upperKC, lowerKC, sarSeries, trendSeries, heuristicSeries, vwapSeries, ema9, ema21, stochasticK, stochasticD, willrSeries, cciSeries, obvSeries,
+    rsiSeries, macdObj, bbWidth, ma20, ma50, ma200, lastClose, var24h, closes, highs, lows, volumes, atrSeries, upperBB, lowerBB, upperKC, lowerKC, adxSeries, sarSeries, trendSeries, heuristicSeries, vwapSeries, ema9, ema21, stochasticK, stochasticD, willrSeries, cciSeries, obvSeries,
     equity,
     riskPct
 }) {
     const start = performance.now();
     const alerts = [];
+    const thresholds = DEFAULT_THRESHOLDS;
+    const rsiThresholds = thresholds.rsi;
 
     const rsi = rsiSeries?.at(-1);
     const prevRsi = rsiSeries?.at(-2);
@@ -22,6 +36,7 @@ export function buildAlerts({
     const prevMacdSignal = macdObj?.signal?.at(-2);
     const price = lastClose;
     const prevPrice = closes?.at(-2);
+    const adxVal = adxSeries?.at(-1);
     const high20 = Math.max(...highs?.slice(-20));
     const low20 = Math.min(...lows?.slice(-20));
     const last20Vol = volumes?.slice(-20);
@@ -51,15 +66,15 @@ export function buildAlerts({
     const prevObv = obvSeries?.at(-2);
 
     // Existing alerts
-    if (rsi != null && rsi > 70) alerts.push("📉 RSI>70 (sobrecompra)");
-    if (rsi != null && rsi < 30) alerts.push("📈 RSI<30 (sobrevenda)");
+    if (rsi != null && rsi > rsiThresholds.overbought) alerts.push("📉 RSI>70 (sobrecompra)");
+    if (rsi != null && rsi < rsiThresholds.oversold) alerts.push("📈 RSI<30 (sobrevenda)");
     if (prevRsi != null && rsi != null) {
-        if (prevRsi > 70 && rsi <= 70) alerts.push("📉 RSI cross-back ↓ (70→<70)");
-        if (prevRsi < 30 && rsi >= 30) alerts.push("📈 RSI cross-back ↑ (<30→>30)");
-        if (prevRsi > 70 && rsi < 70 && rsi >= 50) alerts.push("🔄 RSI neutral (de >70)");
-        if (prevRsi < 30 && rsi > 30 && rsi <= 50) alerts.push("🔄 RSI neutral (de <30)");
-        if (prevRsi < 50 && rsi >= 50) alerts.push("📈 RSI crossed 50↑ (momentum shift)");
-        if (prevRsi > 50 && rsi <= 50) alerts.push("📉 RSI crossed 50↓ (momentum shift)");
+        if (prevRsi > rsiThresholds.overbought && rsi <= rsiThresholds.overbought) alerts.push("📉 RSI cross-back ↓ (70→<70)");
+        if (prevRsi < rsiThresholds.oversold && rsi >= rsiThresholds.oversold) alerts.push("📈 RSI cross-back ↑ (<30→>30)");
+        if (prevRsi > rsiThresholds.overbought && rsi < rsiThresholds.overbought && rsi >= rsiThresholds.midpoint) alerts.push("🔄 RSI neutral (de >70)");
+        if (prevRsi < rsiThresholds.oversold && rsi > rsiThresholds.oversold && rsi <= rsiThresholds.midpoint) alerts.push("🔄 RSI neutral (de <30)");
+        if (prevRsi < rsiThresholds.midpoint && rsi >= rsiThresholds.midpoint) alerts.push("📈 RSI crossed 50↑ (momentum shift)");
+        if (prevRsi > rsiThresholds.midpoint && rsi <= rsiThresholds.midpoint) alerts.push("📉 RSI crossed 50↓ (momentum shift)");
     }
     if (macd != null && macdSignal != null && prevMacd != null && prevMacdSignal != null) {
         if (prevMacd < prevMacdSignal && macd > macdSignal) alerts.push("📈 MACD bullish crossover");
@@ -68,6 +83,7 @@ export function buildAlerts({
     if (macdHist && crossUp(macdHist, Array(macdHist.length).fill(0))) alerts.push("📈 MACD flip ↑");
     if (macdHist && crossDown(macdHist, Array(macdHist.length).fill(0))) alerts.push("📉 MACD flip ↓");
     if (isBBSqueeze(bbWidth)) alerts.push("🧨 BB squeeze (compressão)");
+    if (adxVal != null && adxVal >= thresholds.adx.strongTrend) alerts.push("💪 ADX>25 (tendência forte)");
     if (crossUp(ma20, ma50)) alerts.push("📈 Golden cross 20/50");
     if (crossDown(ma20, ma50)) alerts.push("📉 Death cross 20/50");
     // New alerts
@@ -81,8 +97,8 @@ export function buildAlerts({
     if (price < ma200 && prevPrice >= ma200) alerts.push("📉 Price crossed below MA200");
     if (price >= high20) alerts.push("🚀 New 20-period high");
     if (price <= low20) alerts.push("⚠️ New 20-period low");
-    if (lastVol > 2 * avgVol) alerts.push("🔊 Volume spike (>2x avg)");
-    if (atr > 1.5 * prevAtr) alerts.push("⚡ ATR spike (volatility)");
+    if (avgVol && lastVol > thresholds.volumeSpike * avgVol) alerts.push("🔊 Volume spike (>2x avg)");
+    if (prevAtr != null && atr != null && atr > thresholds.atrSpike * prevAtr) alerts.push("⚡ ATR spike (volatility)");
     if (price > upper) alerts.push("📈 BB breakout above");
     if (price < lower) alerts.push("📉 BB breakout below");
     if (price > upperKeltner) alerts.push("📈 KC breakout above");
@@ -91,22 +107,22 @@ export function buildAlerts({
     if (prevSar > price && sar < price) alerts.push("📈 Parabolic SAR flip bullish");
     if (trend === 1) alerts.push("📈 Strong uptrend");
     if (trend === -1) alerts.push("📉 Strong downtrend");
-    if (heuristic != null && heuristic > 80) alerts.push("🌟 Heuristic score very high");
-    if (heuristic != null && heuristic < 20) alerts.push("⚠️ Heuristic score very low");
+    if (heuristic != null && heuristic > thresholds.heuristic.high) alerts.push("🌟 Heuristic score very high");
+    if (heuristic != null && heuristic < thresholds.heuristic.low) alerts.push("⚠️ Heuristic score very low");
     if (vwap != null && price > vwap && prevPrice <= prevVwap) alerts.push("📈 Price crossed above VWAP");
     if (vwap != null && price < vwap && prevPrice >= prevVwap) alerts.push("📉 Price crossed below VWAP");
     if (ema9Val != null && ema21Val != null && prevEma9 != null && prevEma21 != null) {
         if (prevEma9 < prevEma21 && ema9Val > ema21Val) alerts.push("📈 EMA 9/21 bullish crossover");
         if (prevEma9 > prevEma21 && ema9Val < ema21Val) alerts.push("📉 EMA 9/21 bearish crossover");
     }
-    if (stochK != null && stochK > 80) alerts.push("📉 Stochastic overbought");
-    if (stochK != null && stochK < 20) alerts.push("📈 Stochastic oversold");
-    if (willr != null && willr > -20) alerts.push("📉 Williams %R overbought");
-    if (willr != null && willr < -80) alerts.push("📈 Williams %R oversold");
-    if (cci != null && cci > 100) alerts.push("📉 CCI overbought");
-    if (cci != null && cci < -100) alerts.push("📈 CCI oversold");
-    if (obv != null && prevObv != null && obv > prevObv * 1.05) alerts.push("📈 OBV bullish divergence");
-    if (obv != null && prevObv != null && obv < prevObv * 0.95) alerts.push("📉 OBV bearish divergence");
+    if (stochK != null && stochK > thresholds.stochastic.overbought) alerts.push("📉 Stochastic overbought");
+    if (stochK != null && stochK < thresholds.stochastic.oversold) alerts.push("📈 Stochastic oversold");
+    if (willr != null && willr > thresholds.williamsR.overbought) alerts.push("📉 Williams %R overbought");
+    if (willr != null && willr < thresholds.williamsR.oversold) alerts.push("📈 Williams %R oversold");
+    if (cci != null && cci > thresholds.cci.overbought) alerts.push("📉 CCI overbought");
+    if (cci != null && cci < thresholds.cci.oversold) alerts.push("📈 CCI oversold");
+    if (obv != null && prevObv != null && obv > prevObv * (1 + thresholds.obv.delta)) alerts.push("📈 OBV bullish divergence");
+    if (obv != null && prevObv != null && obv < prevObv * (1 - thresholds.obv.delta)) alerts.push("📉 OBV bearish divergence");
     const threshold = roundThreshold(price);
     if (price % threshold < threshold / 100) alerts.push("🔵 Price near round number");
     alerts.push(`💰 Preço: ${lastClose?.toFixed(4)}`);

--- a/src/index.js
+++ b/src/index.js
@@ -115,6 +115,7 @@ async function runOnceForAsset(asset) {
                 const macdObj = macd(close, 12, 26, 9);
                 const bb = bollinger(close, 20, 2);
                 const kc = keltnerChannel(close, high, low, 20, 2);
+                const adxSeries = adx(high, low, close, 14);
                 const atrSeries = atr14(candles);
                 const bbWidth = bollWidth(bb.upper, bb.lower, bb.mid);
                 const vwapSeries = vwap(high, low, close, vol);
@@ -133,6 +134,7 @@ async function runOnceForAsset(asset) {
                     macdObj,
                     bb,
                     kc,
+                    adxSeries,
                     atrSeries,
                     bbWidth,
                     vwapSeries,
@@ -159,7 +161,9 @@ async function runOnceForAsset(asset) {
                 rsi: indicators.rsiSeries,
                 macdObj: indicators.macdObj,
                 bb: indicators.bb,
+                kc: indicators.kc,
                 atr: indicators.atrSeries,
+                adx: indicators.adxSeries,
                 volSeries: vol
             });
             snapshots[tf] = snapshot;
@@ -194,6 +198,7 @@ async function runOnceForAsset(asset) {
                     lowerBB: indicators.bb.lower,
                     upperKC: indicators.kc.upper,
                     lowerKC: indicators.kc.lower,
+                    adxSeries: indicators.adxSeries,
                     vwapSeries: indicators.vwapSeries,
                     ema9: indicators.ema9Series,
                     ema21: indicators.ema21Series,

--- a/tests/alerts.test.js
+++ b/tests/alerts.test.js
@@ -16,13 +16,15 @@ describe('buildAlerts', () => {
       lows: Array(21).fill(80),
       volumes: Array(21).fill(1000),
       upperKC: Array(21).fill(99),
-      lowerKC: Array(21).fill(80)
+      lowerKC: Array(21).fill(80),
+      adxSeries: [30]
     };
     const alerts = buildAlerts(data);
     expect(alerts).toContain('📉 RSI>70 (sobrecompra)');
     expect(alerts).toContain('📈 MACD flip ↑');
     expect(alerts).toContain('📈 Golden cross 20/50');
     expect(alerts).toContain('📈 KC breakout above');
+    expect(alerts).toContain('💪 ADX>25 (tendência forte)');
     expect(alerts).toContain('💰 Preço: 100.0000');
   });
 


### PR DESCRIPTION
## Summary
- compute ADX and Keltner channel data when building indicator caches
- surface ADX readings and Keltner positioning inside analysis snapshots and summaries
- standardize alert thresholds (including ADX>25) and update alert coverage tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d16647e2b883268275ba65f59dc6ad