### PR TITLE
feat: make indicator parameters configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,40 @@ MAX_CONCURRENCY=4
 # BINANCE_CACHE_TTL_MINUTES: tempo de cache (minutos) para dados da Binance
 BINANCE_CACHE_TTL_MINUTES=10
 
+## Indicadores técnicos
+# INDICATOR_SMA_PERIODS: períodos das médias móveis simples (ordem: ma20, ma50, ma100, ma200)
+INDICATOR_SMA_PERIODS=20,50,100,200
+# INDICATOR_EMA_PERIODS: períodos das médias móveis exponenciais (ordem: ema9, ema21)
+INDICATOR_EMA_PERIODS=9,21
+# INDICATOR_RSI_PERIOD: período do RSI
+INDICATOR_RSI_PERIOD=14
+# INDICATOR_MACD_FAST: período rápido do MACD
+INDICATOR_MACD_FAST=12
+# INDICATOR_MACD_SLOW: período lento do MACD
+INDICATOR_MACD_SLOW=26
+# INDICATOR_MACD_SIGNAL: período da linha de sinal do MACD
+INDICATOR_MACD_SIGNAL=9
+# INDICATOR_BB_PERIOD: período das Bandas de Bollinger
+INDICATOR_BB_PERIOD=20
+# INDICATOR_BB_MULTIPLIER: multiplicador do desvio padrão nas Bandas de Bollinger
+INDICATOR_BB_MULTIPLIER=2
+# INDICATOR_KC_PERIOD: período do Canal de Keltner
+INDICATOR_KC_PERIOD=20
+# INDICATOR_KC_MULTIPLIER: multiplicador do Canal de Keltner
+INDICATOR_KC_MULTIPLIER=2
+# INDICATOR_ADX_PERIOD: período do ADX
+INDICATOR_ADX_PERIOD=14
+# INDICATOR_ATR_PERIOD: período do ATR
+INDICATOR_ATR_PERIOD=14
+# INDICATOR_STOCH_K_PERIOD: período %K do Estocástico
+INDICATOR_STOCH_K_PERIOD=14
+# INDICATOR_STOCH_D_PERIOD: período %D do Estocástico
+INDICATOR_STOCH_D_PERIOD=3
+# INDICATOR_WILLR_PERIOD: período do Williams %R
+INDICATOR_WILLR_PERIOD=14
+# INDICATOR_CCI_PERIOD: período do CCI
+INDICATOR_CCI_PERIOD=20
+
 ## OpenRouter API
 # OPENROUTER_API_KEY: chave de acesso ao OpenRouter
 OPENROUTER_API_KEY=your-openrouter-key

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ Key variables:
 
 - `MAX_CONCURRENCY` – optional limit for parallel analyses. When omitted or invalid the bot automatically matches the number of available CPU cores; set to `1` to force sequential processing.
 - `BINANCE_CACHE_TTL_MINUTES` – cache duration for Binance price data in minutes (defaults to 10 minutes when unset or invalid). This value is available at runtime as `CFG.binanceCacheTTL` and controls the TTL of the shared Binance `LRUCache` instance.
+- Indicator overrides – the `CFG.indicators` section centralises every period and multiplier used while computing technical indicators. Environment variables such as `INDICATOR_SMA_PERIODS`, `INDICATOR_MACD_FAST` or `INDICATOR_BB_MULTIPLIER` let you customise the moving averages, MACD windows and Bollinger/Keltner multipliers without touching the codebase. See `.env.example` for concrete values.
+
+Example snippet for `.env`:
+
+```dotenv
+INDICATOR_SMA_PERIODS=10,40,100,200
+INDICATOR_MACD_FAST=8
+INDICATOR_MACD_SLOW=21
+INDICATOR_MACD_SIGNAL=5
+INDICATOR_BB_MULTIPLIER=2.5
+```
 
 ## Technical Articles
 

--- a/src/config.js
+++ b/src/config.js
@@ -7,6 +7,70 @@ const binanceCacheTTL = Number.isFinite(parsedBinanceCacheTTL) && parsedBinanceC
     ? parsedBinanceCacheTTL
     : DEFAULT_BINANCE_CACHE_TTL_MINUTES;
 
+const toNumber = (value, fallback) => {
+    const parsed = Number.parseFloat(value ?? '');
+    return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const toInt = (value, fallback) => {
+    const parsed = Number.parseInt(value ?? '', 10);
+    return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const toNumberList = (value, fallback, expectedLength) => {
+    if (!value) return fallback;
+    const parsed = value
+        .split(',')
+        .map(part => Number.parseFloat(part.trim()))
+        .filter(n => Number.isFinite(n));
+    if (expectedLength && parsed.length < expectedLength) {
+        return fallback;
+    }
+    return parsed.length ? parsed : fallback;
+};
+
+const buildIndicatorConfig = () => {
+    const defaultSma = [20, 50, 100, 200];
+    const smaValues = toNumberList(process.env.INDICATOR_SMA_PERIODS, defaultSma, defaultSma.length);
+    const defaultEma = [9, 21];
+    const emaValues = toNumberList(process.env.INDICATOR_EMA_PERIODS, defaultEma, defaultEma.length);
+
+    return {
+        smaPeriods: {
+            ma20: smaValues[0] ?? defaultSma[0],
+            ma50: smaValues[1] ?? defaultSma[1],
+            ma100: smaValues[2] ?? defaultSma[2],
+            ma200: smaValues[3] ?? defaultSma[3]
+        },
+        emaPeriods: {
+            ema9: emaValues[0] ?? defaultEma[0],
+            ema21: emaValues[1] ?? defaultEma[1]
+        },
+        rsiPeriod: toInt(process.env.INDICATOR_RSI_PERIOD, 14),
+        macd: {
+            fast: toInt(process.env.INDICATOR_MACD_FAST, 12),
+            slow: toInt(process.env.INDICATOR_MACD_SLOW, 26),
+            signal: toInt(process.env.INDICATOR_MACD_SIGNAL, 9)
+        },
+        bollinger: {
+            period: toInt(process.env.INDICATOR_BB_PERIOD, 20),
+            multiplier: toNumber(process.env.INDICATOR_BB_MULTIPLIER, 2)
+        },
+        keltner: {
+            period: toInt(process.env.INDICATOR_KC_PERIOD, 20),
+            multiplier: toNumber(process.env.INDICATOR_KC_MULTIPLIER, 2)
+        },
+        adxPeriod: toInt(process.env.INDICATOR_ADX_PERIOD, 14),
+        atrPeriod: toInt(process.env.INDICATOR_ATR_PERIOD, 14),
+        stochastic: {
+            kPeriod: toInt(process.env.INDICATOR_STOCH_K_PERIOD, 14),
+            dPeriod: toInt(process.env.INDICATOR_STOCH_D_PERIOD, 3)
+        },
+        williamsPeriod: toInt(process.env.INDICATOR_WILLR_PERIOD, 14),
+        cciPeriod: toInt(process.env.INDICATOR_CCI_PERIOD, 20)
+    };
+};
+
 export const CFG = {
     webhook: process.env.DISCORD_WEBHOOK_URL,
     webhookAlerts: process.env.DISCORD_WEBHOOK_ALERTS_URL,
@@ -38,6 +102,7 @@ export const CFG = {
     alertDedupMinutes: parseFloat(process.env.ALERT_DEDUP_MINUTES || '60'),
     binanceCacheTTL,
     maxConcurrency: process.env.MAX_CONCURRENCY ? parseInt(process.env.MAX_CONCURRENCY, 10) : undefined,
+    indicators: buildIndicatorConfig()
 };
 
 export const config = {

--- a/src/index.js
+++ b/src/index.js
@@ -107,23 +107,24 @@ async function runOnceForAsset(asset) {
             const low = candles.map(c => c.l);
 
             const indicators = indicatorCache.get(tf) ?? (() => {
-                const ma20 = sma(close, 20);
-                const ma50 = sma(close, 50);
-                const ma100 = sma(close, 100);
-                const ma200 = sma(close, 200);
-                const rsiSeries = rsi(close, 14);
-                const macdObj = macd(close, 12, 26, 9);
-                const bb = bollinger(close, 20, 2);
-                const kc = keltnerChannel(close, high, low, 20, 2);
-                const adxSeries = adx(high, low, close, 14);
-                const atrSeries = atr14(candles);
+                const cfg = CFG.indicators;
+                const ma20 = sma(close, cfg.smaPeriods.ma20);
+                const ma50 = sma(close, cfg.smaPeriods.ma50);
+                const ma100 = sma(close, cfg.smaPeriods.ma100);
+                const ma200 = sma(close, cfg.smaPeriods.ma200);
+                const rsiSeries = rsi(close, cfg.rsiPeriod);
+                const macdObj = macd(close, cfg.macd.fast, cfg.macd.slow, cfg.macd.signal);
+                const bb = bollinger(close, cfg.bollinger.period, cfg.bollinger.multiplier);
+                const kc = keltnerChannel(close, high, low, cfg.keltner.period, cfg.keltner.multiplier);
+                const adxSeries = adx(high, low, close, cfg.adxPeriod);
+                const atrSeries = atr14(candles, cfg.atrPeriod);
                 const bbWidth = bollWidth(bb.upper, bb.lower, bb.mid);
                 const vwapSeries = vwap(high, low, close, vol);
-                const ema9Series = ema(close, 9);
-                const ema21Series = ema(close, 21);
-                const { k: stochasticK, d: stochasticD } = stochastic(high, low, close, 14, 3);
-                const willrSeries = williamsR(high, low, close, 14);
-                const cciSeries = cci(high, low, close, 20);
+                const ema9Series = ema(close, cfg.emaPeriods.ema9);
+                const ema21Series = ema(close, cfg.emaPeriods.ema21);
+                const { k: stochasticK, d: stochasticD } = stochastic(high, low, close, cfg.stochastic.kPeriod, cfg.stochastic.dPeriod);
+                const willrSeries = williamsR(high, low, close, cfg.williamsPeriod);
+                const cciSeries = cci(high, low, close, cfg.cciPeriod);
                 const obvSeries = obv(close, vol);
                 const computed = {
                     ma20,

--- a/src/indicators.js
+++ b/src/indicators.js
@@ -322,7 +322,7 @@ export function obv(closes, volumes) {
     return out;
 }
 
-export function atr14(ohlc) {
+export function atr14(ohlc, period = 14) {
     const tr = [];
     for (let i = 0; i < ohlc.length; i++) {
         if (i === 0) { tr.push(ohlc[i].h - ohlc[i].l); continue; }
@@ -333,7 +333,8 @@ export function atr14(ohlc) {
         tr.push(Math.max(a, b, c));
     }
     // EMA ATR(14)
-    const n = 14, k = 2 / (n + 1);
+    const n = Number.isFinite(period) && period > 0 ? Math.round(period) : 14;
+    const k = 2 / (n + 1);
     const out = [];
     tr.forEach((v, i) => out.push(i ? (v * k + out[i - 1] * (1 - k)) : v));
     return out;


### PR DESCRIPTION
## Summary
- add an `indicators` section to CFG populated from new environment variables
- read the configured periods and multipliers when computing indicators in the main runner
- document the new settings with concrete `.env` examples for quick tuning

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d16fcc7cf88326ac599c5409c7588a