### PR TITLE
Add alert severity levels and formatting

### DIFF
--- a/src/ai.js
+++ b/src/ai.js
@@ -52,7 +52,7 @@ import { fetchOHLCV } from "./data/binance.js";
 import { getAssetNews } from "./news.js";
 import { searchWeb } from "./websearch.js";
 import { sma, rsi, macd, atr14, bollinger, bollWidth, crossUp, crossDown, parabolicSAR, semaforo, isBBSqueeze, sparkline, volumeDivergence, trendFromMAs, scoreHeuristic, vwap, ema, stochastic, williamsR, cci, obv } from "./indicators.js";
-import { buildAlerts } from "./alerts.js";
+import { buildAlerts, formatAlertMessage } from "./alerts.js";
 import { logger, withContext } from "./logger.js";
 
 const openrouter = CFG.openrouterApiKey
@@ -280,7 +280,7 @@ export async function runAgent() {
             const report = [
                 ...baseReport,
                 `**Alert Status:**`,
-                ...alerts,
+                ...alerts.map(alert => `- ${formatAlertMessage(alert)}`),
                 `- News: ${newsSummary || 'n/a'}`,
                 `- Web: ${webSnips.slice(0, 2).join(' | ') || 'n/a'}`,
                 `- Macro: ${macro || 'n/a'}`,

--- a/src/alerts.js
+++ b/src/alerts.js
@@ -3,6 +3,19 @@ import { logger, withContext } from './logger.js';
 import { recordPerf } from './perf.js';
 import { CFG } from './config.js';
 import { DEFAULT_ALERT_MODULES } from './alerts/registry.js';
+import { ALERT_LEVELS } from './alerts/shared.js';
+
+const LEVEL_ORDER = {
+    [ALERT_LEVELS.HIGH]: 0,
+    [ALERT_LEVELS.MEDIUM]: 1,
+    [ALERT_LEVELS.LOW]: 2
+};
+
+const LEVEL_STYLES = {
+    [ALERT_LEVELS.HIGH]: { emoji: '🔴', label: 'ALTA' },
+    [ALERT_LEVELS.MEDIUM]: { emoji: '🟠', label: 'MÉDIA' },
+    [ALERT_LEVELS.LOW]: { emoji: '🟢', label: 'BAIXA' }
+};
 
 const moduleCache = new Map();
 
@@ -35,10 +48,19 @@ function normalizeAlerts(result) {
     if (!result) {
         return [];
     }
-    if (Array.isArray(result)) {
-        return result.filter(Boolean);
-    }
-    return [result].filter(Boolean);
+    const items = Array.isArray(result) ? result : [result];
+    return items
+        .filter(Boolean)
+        .map(alert => {
+            if (alert && typeof alert === 'object' && 'msg' in alert && 'level' in alert) {
+                return alert;
+            }
+            if (typeof alert === 'string') {
+                return { msg: alert, level: ALERT_LEVELS.MEDIUM };
+            }
+            return null;
+        })
+        .filter(Boolean);
 }
 
 export async function buildAlerts(context) {
@@ -68,5 +90,18 @@ export async function buildAlerts(context) {
     const ms = performance.now() - start;
     log.debug({ fn: 'buildAlerts', ms }, 'duration');
     recordPerf('buildAlerts', ms);
+    alerts.sort((a, b) => {
+        const aOrder = LEVEL_ORDER[a.level] ?? LEVEL_ORDER[ALERT_LEVELS.MEDIUM];
+        const bOrder = LEVEL_ORDER[b.level] ?? LEVEL_ORDER[ALERT_LEVELS.MEDIUM];
+        return aOrder - bOrder;
+    });
+
     return alerts;
 }
+
+export function formatAlertMessage({ msg, level }) {
+    const { emoji, label } = LEVEL_STYLES[level] ?? LEVEL_STYLES[ALERT_LEVELS.MEDIUM];
+    return `${emoji} **${label}:** ${msg}`;
+}
+
+export { ALERT_LEVELS };

--- a/src/alerts/adxAlert.js
+++ b/src/alerts/adxAlert.js
@@ -1,9 +1,11 @@
+import { ALERT_LEVELS, createAlert } from './shared.js';
+
 export default function adxAlert({ adxSeries, thresholds }) {
     const alerts = [];
     const adx = adxSeries?.at(-1);
     const { adxStrongTrend } = thresholds ?? {};
     if (adx != null && adxStrongTrend != null && adx >= adxStrongTrend) {
-        alerts.push("💪 ADX>25 (tendência forte)");
+        alerts.push(createAlert("💪 ADX>25 (tendência forte)", ALERT_LEVELS.HIGH));
     }
     return alerts;
 }

--- a/src/alerts/atrAlert.js
+++ b/src/alerts/atrAlert.js
@@ -1,3 +1,5 @@
+import { ALERT_LEVELS, createAlert } from './shared.js';
+
 export default function atrAlert({ atrSeries, thresholds }) {
     const alerts = [];
     const atr = atrSeries?.at(-1);
@@ -5,7 +7,7 @@ export default function atrAlert({ atrSeries, thresholds }) {
     const { atrSpike } = thresholds ?? {};
 
     if (atr != null && prevAtr != null && atrSpike != null && atr > atrSpike * prevAtr) {
-        alerts.push("⚡ ATR spike (volatility)");
+        alerts.push(createAlert("⚡ ATR spike (volatility)", ALERT_LEVELS.HIGH));
     }
 
     return alerts;

--- a/src/alerts/bollingerAlert.js
+++ b/src/alerts/bollingerAlert.js
@@ -1,4 +1,5 @@
 import { isBBSqueeze } from '../indicators.js';
+import { ALERT_LEVELS, createAlert } from './shared.js';
 
 export default function bollingerAlert({ bbWidth, lastClose, upperBB, lowerBB, upperKC, lowerKC }) {
     const alerts = [];
@@ -9,19 +10,19 @@ export default function bollingerAlert({ bbWidth, lastClose, upperBB, lowerBB, u
     const lowerKeltner = lowerKC?.at(-1);
 
     if (Array.isArray(bbWidth) && bbWidth.length > 0 && isBBSqueeze(bbWidth)) {
-        alerts.push("🧨 BB squeeze (compressão)");
+        alerts.push(createAlert("🧨 BB squeeze (compressão)", ALERT_LEVELS.MEDIUM));
     }
     if (price != null && upper != null && price > upper) {
-        alerts.push("📈 BB breakout above");
+        alerts.push(createAlert("📈 BB breakout above", ALERT_LEVELS.HIGH));
     }
     if (price != null && lower != null && price < lower) {
-        alerts.push("📉 BB breakout below");
+        alerts.push(createAlert("📉 BB breakout below", ALERT_LEVELS.HIGH));
     }
     if (price != null && upperKeltner != null && price > upperKeltner) {
-        alerts.push("📈 KC breakout above");
+        alerts.push(createAlert("📈 KC breakout above", ALERT_LEVELS.HIGH));
     }
     if (price != null && lowerKeltner != null && price < lowerKeltner) {
-        alerts.push("📉 KC breakout below");
+        alerts.push(createAlert("📉 KC breakout below", ALERT_LEVELS.HIGH));
     }
 
     return alerts;

--- a/src/alerts/cciAlert.js
+++ b/src/alerts/cciAlert.js
@@ -1,13 +1,15 @@
+import { ALERT_LEVELS, createAlert } from './shared.js';
+
 export default function cciAlert({ cciSeries, thresholds }) {
     const alerts = [];
     const cci = cciSeries?.at(-1);
     const { cciOverbought, cciOversold } = thresholds ?? {};
 
     if (cci != null && cciOverbought != null && cci > cciOverbought) {
-        alerts.push("📉 CCI overbought");
+        alerts.push(createAlert("📉 CCI overbought", ALERT_LEVELS.MEDIUM));
     }
     if (cci != null && cciOversold != null && cci < cciOversold) {
-        alerts.push("📈 CCI oversold");
+        alerts.push(createAlert("📈 CCI oversold", ALERT_LEVELS.MEDIUM));
     }
 
     return alerts;

--- a/src/alerts/emaCrossoverAlert.js
+++ b/src/alerts/emaCrossoverAlert.js
@@ -1,3 +1,5 @@
+import { ALERT_LEVELS, createAlert } from './shared.js';
+
 export default function emaCrossoverAlert({ ema9, ema21 }) {
     const alerts = [];
     const ema9Val = ema9?.at(-1);
@@ -7,10 +9,10 @@ export default function emaCrossoverAlert({ ema9, ema21 }) {
 
     if (ema9Val != null && ema21Val != null && prevEma9 != null && prevEma21 != null) {
         if (prevEma9 < prevEma21 && ema9Val > ema21Val) {
-            alerts.push("📈 EMA 9/21 bullish crossover");
+            alerts.push(createAlert("📈 EMA 9/21 bullish crossover", ALERT_LEVELS.HIGH));
         }
         if (prevEma9 > prevEma21 && ema9Val < ema21Val) {
-            alerts.push("📉 EMA 9/21 bearish crossover");
+            alerts.push(createAlert("📉 EMA 9/21 bearish crossover", ALERT_LEVELS.HIGH));
         }
     }
 

--- a/src/alerts/heuristicAlert.js
+++ b/src/alerts/heuristicAlert.js
@@ -1,13 +1,15 @@
+import { ALERT_LEVELS, createAlert } from './shared.js';
+
 export default function heuristicAlert({ heuristicSeries, thresholds }) {
     const alerts = [];
     const heuristic = heuristicSeries?.at(-1);
     const { heuristicHigh, heuristicLow } = thresholds ?? {};
 
     if (heuristic != null && heuristicHigh != null && heuristic > heuristicHigh) {
-        alerts.push("🌟 Heuristic score very high");
+        alerts.push(createAlert("🌟 Heuristic score very high", ALERT_LEVELS.HIGH));
     }
     if (heuristic != null && heuristicLow != null && heuristic < heuristicLow) {
-        alerts.push("⚠️ Heuristic score very low");
+        alerts.push(createAlert("⚠️ Heuristic score very low", ALERT_LEVELS.HIGH));
     }
 
     return alerts;

--- a/src/alerts/highLowAlert.js
+++ b/src/alerts/highLowAlert.js
@@ -1,3 +1,5 @@
+import { ALERT_LEVELS, createAlert } from './shared.js';
+
 export default function highLowAlert({ highs, lows, lastClose }) {
     const alerts = [];
     const price = lastClose;
@@ -7,10 +9,10 @@ export default function highLowAlert({ highs, lows, lastClose }) {
     const minLow = low20 && low20.length ? Math.min(...low20) : undefined;
 
     if (price != null && maxHigh != null && price >= maxHigh) {
-        alerts.push("🚀 New 20-period high");
+        alerts.push(createAlert("🚀 New 20-period high", ALERT_LEVELS.HIGH));
     }
     if (price != null && minLow != null && price <= minLow) {
-        alerts.push("⚠️ New 20-period low");
+        alerts.push(createAlert("⚠️ New 20-period low", ALERT_LEVELS.HIGH));
     }
 
     return alerts;

--- a/src/alerts/maCrossoverAlert.js
+++ b/src/alerts/maCrossoverAlert.js
@@ -1,4 +1,5 @@
 import { crossUp, crossDown } from '../indicators.js';
+import { ALERT_LEVELS, createAlert } from './shared.js';
 
 export default function maCrossoverAlert({ ma20, ma50, ma200 }) {
     if (!Array.isArray(ma20) || !Array.isArray(ma50)) {
@@ -7,17 +8,17 @@ export default function maCrossoverAlert({ ma20, ma50, ma200 }) {
 
     const alerts = [];
     if (crossUp(ma20, ma50)) {
-        alerts.push("📈 Golden cross 20/50");
+        alerts.push(createAlert("📈 Golden cross 20/50", ALERT_LEVELS.HIGH));
     }
     if (crossDown(ma20, ma50)) {
-        alerts.push("📉 Death cross 20/50");
+        alerts.push(createAlert("📉 Death cross 20/50", ALERT_LEVELS.HIGH));
     }
     if (Array.isArray(ma200)) {
         if (crossUp(ma50, ma200)) {
-            alerts.push("📈 Golden cross 50/200");
+            alerts.push(createAlert("📈 Golden cross 50/200", ALERT_LEVELS.HIGH));
         }
         if (crossDown(ma50, ma200)) {
-            alerts.push("📉 Death cross 50/200");
+            alerts.push(createAlert("📉 Death cross 50/200", ALERT_LEVELS.HIGH));
         }
     }
     return alerts;

--- a/src/alerts/maPriceAlert.js
+++ b/src/alerts/maPriceAlert.js
@@ -1,3 +1,5 @@
+import { ALERT_LEVELS, createAlert } from './shared.js';
+
 export default function maPriceAlert({ ma20, ma50, ma200, lastClose, closes }) {
     const alerts = [];
     const price = lastClose;
@@ -8,26 +10,26 @@ export default function maPriceAlert({ ma20, ma50, ma200, lastClose, closes }) {
 
     if (price != null && prevPrice != null && ma20Val != null) {
         if (price > ma20Val && prevPrice <= ma20Val) {
-            alerts.push("📈 Price crossed above MA20");
+            alerts.push(createAlert("📈 Price crossed above MA20", ALERT_LEVELS.MEDIUM));
         }
         if (price < ma20Val && prevPrice >= ma20Val) {
-            alerts.push("📉 Price crossed below MA20");
+            alerts.push(createAlert("📉 Price crossed below MA20", ALERT_LEVELS.MEDIUM));
         }
     }
     if (price != null && prevPrice != null && ma50Val != null) {
         if (price > ma50Val && prevPrice <= ma50Val) {
-            alerts.push("📈 Price crossed above MA50");
+            alerts.push(createAlert("📈 Price crossed above MA50", ALERT_LEVELS.MEDIUM));
         }
         if (price < ma50Val && prevPrice >= ma50Val) {
-            alerts.push("📉 Price crossed below MA50");
+            alerts.push(createAlert("📉 Price crossed below MA50", ALERT_LEVELS.MEDIUM));
         }
     }
     if (price != null && prevPrice != null && ma200Val != null) {
         if (price > ma200Val && prevPrice <= ma200Val) {
-            alerts.push("📈 Price crossed above MA200");
+            alerts.push(createAlert("📈 Price crossed above MA200", ALERT_LEVELS.HIGH));
         }
         if (price < ma200Val && prevPrice >= ma200Val) {
-            alerts.push("📉 Price crossed below MA200");
+            alerts.push(createAlert("📉 Price crossed below MA200", ALERT_LEVELS.HIGH));
         }
     }
 

--- a/src/alerts/macdAlert.js
+++ b/src/alerts/macdAlert.js
@@ -1,4 +1,5 @@
 import { crossUp, crossDown } from '../indicators.js';
+import { ALERT_LEVELS, createAlert } from './shared.js';
 
 export default function macdAlert({ macdObj }) {
     const alerts = [];
@@ -10,20 +11,20 @@ export default function macdAlert({ macdObj }) {
 
     if (macd != null && macdSignal != null && prevMacd != null && prevSignal != null) {
         if (prevMacd < prevSignal && macd > macdSignal) {
-            alerts.push("📈 MACD bullish crossover");
+            alerts.push(createAlert("📈 MACD bullish crossover", ALERT_LEVELS.HIGH));
         }
         if (prevMacd > prevSignal && macd < macdSignal) {
-            alerts.push("📉 MACD bearish crossover");
+            alerts.push(createAlert("📉 MACD bearish crossover", ALERT_LEVELS.HIGH));
         }
     }
 
     if (macdHist && macdHist.length >= 2) {
         const zeros = Array(macdHist.length).fill(0);
         if (crossUp(macdHist, zeros)) {
-            alerts.push("📈 MACD flip ↑");
+            alerts.push(createAlert("📈 MACD flip ↑", ALERT_LEVELS.MEDIUM));
         }
         if (crossDown(macdHist, zeros)) {
-            alerts.push("📉 MACD flip ↓");
+            alerts.push(createAlert("📉 MACD flip ↓", ALERT_LEVELS.MEDIUM));
         }
     }
 

--- a/src/alerts/obvAlert.js
+++ b/src/alerts/obvAlert.js
@@ -1,3 +1,5 @@
+import { ALERT_LEVELS, createAlert } from './shared.js';
+
 export default function obvAlert({ obvSeries, thresholds }) {
     const alerts = [];
     const obv = obvSeries?.at(-1);
@@ -6,10 +8,10 @@ export default function obvAlert({ obvSeries, thresholds }) {
 
     if (obv != null && prevObv != null && obvDelta != null) {
         if (obv > prevObv * (1 + obvDelta)) {
-            alerts.push("📈 OBV bullish divergence");
+            alerts.push(createAlert("📈 OBV bullish divergence", ALERT_LEVELS.MEDIUM));
         }
         if (obv < prevObv * (1 - obvDelta)) {
-            alerts.push("📉 OBV bearish divergence");
+            alerts.push(createAlert("📉 OBV bearish divergence", ALERT_LEVELS.MEDIUM));
         }
     }
 

--- a/src/alerts/priceInfoAlert.js
+++ b/src/alerts/priceInfoAlert.js
@@ -1,6 +1,8 @@
+import { ALERT_LEVELS, createAlert } from './shared.js';
+
 export default function priceInfoAlert({ lastClose }) {
     if (lastClose == null) {
         return [];
     }
-    return [`💰 Preço: ${lastClose.toFixed(4)}`];
+    return [createAlert(`💰 Preço: ${lastClose.toFixed(4)}`, ALERT_LEVELS.LOW)];
 }

--- a/src/alerts/roundNumberAlert.js
+++ b/src/alerts/roundNumberAlert.js
@@ -1,4 +1,5 @@
 import { roundThreshold } from '../utils.js';
+import { ALERT_LEVELS, createAlert } from './shared.js';
 
 export default function roundNumberAlert({ lastClose }) {
     const alerts = [];
@@ -6,7 +7,7 @@ export default function roundNumberAlert({ lastClose }) {
     if (price != null) {
         const threshold = roundThreshold(price);
         if (threshold && price % threshold < threshold / 100) {
-            alerts.push("🔵 Price near round number");
+            alerts.push(createAlert("🔵 Price near round number", ALERT_LEVELS.LOW));
         }
     }
     return alerts;

--- a/src/alerts/rsiAlert.js
+++ b/src/alerts/rsiAlert.js
@@ -1,3 +1,5 @@
+import { ALERT_LEVELS, createAlert } from './shared.js';
+
 export default function rsiAlert({ rsiSeries, thresholds }) {
     const alerts = [];
     const rsi = rsiSeries?.at(-1);
@@ -9,17 +11,17 @@ export default function rsiAlert({ rsiSeries, thresholds }) {
     } = thresholds ?? {};
 
     if (rsi != null && rsiOverbought != null && rsi > rsiOverbought) {
-        alerts.push("📉 RSI>70 (sobrecompra)");
+        alerts.push(createAlert("📉 RSI>70 (sobrecompra)", ALERT_LEVELS.HIGH));
     }
     if (rsi != null && rsiOversold != null && rsi < rsiOversold) {
-        alerts.push("📈 RSI<30 (sobrevenda)");
+        alerts.push(createAlert("📈 RSI<30 (sobrevenda)", ALERT_LEVELS.HIGH));
     }
     if (prevRsi != null && rsi != null) {
         if (rsiOverbought != null && prevRsi > rsiOverbought && rsi <= rsiOverbought) {
-            alerts.push("📉 RSI cross-back ↓ (70→<70)");
+            alerts.push(createAlert("📉 RSI cross-back ↓ (70→<70)", ALERT_LEVELS.MEDIUM));
         }
         if (rsiOversold != null && prevRsi < rsiOversold && rsi >= rsiOversold) {
-            alerts.push("📈 RSI cross-back ↑ (<30→>30)");
+            alerts.push(createAlert("📈 RSI cross-back ↑ (<30→>30)", ALERT_LEVELS.MEDIUM));
         }
         if (
             rsiOverbought != null && rsiMidpoint != null &&
@@ -27,7 +29,7 @@ export default function rsiAlert({ rsiSeries, thresholds }) {
             rsi < rsiOverbought &&
             rsi >= rsiMidpoint
         ) {
-            alerts.push("🔄 RSI neutral (de >70)");
+            alerts.push(createAlert("🔄 RSI neutral (de >70)", ALERT_LEVELS.LOW));
         }
         if (
             rsiOversold != null && rsiMidpoint != null &&
@@ -35,13 +37,13 @@ export default function rsiAlert({ rsiSeries, thresholds }) {
             rsi > rsiOversold &&
             rsi <= rsiMidpoint
         ) {
-            alerts.push("🔄 RSI neutral (de <30)");
+            alerts.push(createAlert("🔄 RSI neutral (de <30)", ALERT_LEVELS.LOW));
         }
         if (rsiMidpoint != null && prevRsi < rsiMidpoint && rsi >= rsiMidpoint) {
-            alerts.push("📈 RSI crossed 50↑ (momentum shift)");
+            alerts.push(createAlert("📈 RSI crossed 50↑ (momentum shift)", ALERT_LEVELS.MEDIUM));
         }
         if (rsiMidpoint != null && prevRsi > rsiMidpoint && rsi <= rsiMidpoint) {
-            alerts.push("📉 RSI crossed 50↓ (momentum shift)");
+            alerts.push(createAlert("📉 RSI crossed 50↓ (momentum shift)", ALERT_LEVELS.MEDIUM));
         }
     }
 

--- a/src/alerts/sarAlert.js
+++ b/src/alerts/sarAlert.js
@@ -1,3 +1,5 @@
+import { ALERT_LEVELS, createAlert } from './shared.js';
+
 export default function sarAlert({ sarSeries, lastClose }) {
     const alerts = [];
     const price = lastClose;
@@ -6,10 +8,10 @@ export default function sarAlert({ sarSeries, lastClose }) {
 
     if (price != null && sar != null && prevSar != null) {
         if (prevSar < price && sar > price) {
-            alerts.push("📉 Parabolic SAR flip bearish");
+            alerts.push(createAlert("📉 Parabolic SAR flip bearish", ALERT_LEVELS.HIGH));
         }
         if (prevSar > price && sar < price) {
-            alerts.push("📈 Parabolic SAR flip bullish");
+            alerts.push(createAlert("📈 Parabolic SAR flip bullish", ALERT_LEVELS.HIGH));
         }
     }
 

--- a/src/alerts/shared.js
+++ b/src/alerts/shared.js
@@ -1,0 +1,9 @@
+export const ALERT_LEVELS = Object.freeze({
+    HIGH: 'high',
+    MEDIUM: 'medium',
+    LOW: 'low'
+});
+
+export function createAlert(msg, level = ALERT_LEVELS.MEDIUM) {
+    return { msg, level };
+}

--- a/src/alerts/stochasticAlert.js
+++ b/src/alerts/stochasticAlert.js
@@ -1,13 +1,15 @@
+import { ALERT_LEVELS, createAlert } from './shared.js';
+
 export default function stochasticAlert({ stochasticK, thresholds }) {
     const alerts = [];
     const stochK = stochasticK?.at(-1);
     const { stochasticOverbought, stochasticOversold } = thresholds ?? {};
 
     if (stochK != null && stochasticOverbought != null && stochK > stochasticOverbought) {
-        alerts.push("📉 Stochastic overbought");
+        alerts.push(createAlert("📉 Stochastic overbought", ALERT_LEVELS.MEDIUM));
     }
     if (stochK != null && stochasticOversold != null && stochK < stochasticOversold) {
-        alerts.push("📈 Stochastic oversold");
+        alerts.push(createAlert("📈 Stochastic oversold", ALERT_LEVELS.MEDIUM));
     }
 
     return alerts;

--- a/src/alerts/tradeLevelsAlert.js
+++ b/src/alerts/tradeLevelsAlert.js
@@ -1,4 +1,5 @@
 import { atrStopTarget, positionSize } from '../trading/risk.js';
+import { ALERT_LEVELS, createAlert } from './shared.js';
 
 export default function tradeLevelsAlert({ lastClose, atrSeries, equity, riskPct }) {
     const alerts = [];
@@ -9,7 +10,10 @@ export default function tradeLevelsAlert({ lastClose, atrSeries, equity, riskPct
         const { stop, target } = atrStopTarget(price, atr);
         const size = positionSize(equity, riskPct, price, stop);
         if (stop != null && target != null && Number.isFinite(size)) {
-            alerts.push(`🎯 Stop ${stop.toFixed(4)} / Target ${target.toFixed(4)} / Size ${size.toFixed(4)}`);
+            alerts.push(createAlert(
+                `🎯 Stop ${stop.toFixed(4)} / Target ${target.toFixed(4)} / Size ${size.toFixed(4)}`,
+                ALERT_LEVELS.LOW
+            ));
         }
     }
 

--- a/src/alerts/trendAlert.js
+++ b/src/alerts/trendAlert.js
@@ -1,11 +1,13 @@
+import { ALERT_LEVELS, createAlert } from './shared.js';
+
 export default function trendAlert({ trendSeries }) {
     const alerts = [];
     const trend = trendSeries?.at(-1);
     if (trend === 1) {
-        alerts.push("📈 Strong uptrend");
+        alerts.push(createAlert("📈 Strong uptrend", ALERT_LEVELS.HIGH));
     }
     if (trend === -1) {
-        alerts.push("📉 Strong downtrend");
+        alerts.push(createAlert("📉 Strong downtrend", ALERT_LEVELS.HIGH));
     }
     return alerts;
 }

--- a/src/alerts/varAlert.js
+++ b/src/alerts/varAlert.js
@@ -1,7 +1,9 @@
+import { ALERT_LEVELS, createAlert } from './shared.js';
+
 export default function varAlert({ var24h }) {
     if (var24h == null) {
         return [];
     }
     const prefix = var24h > 0 ? '+' : '';
-    return [`📊 Var24h: ${prefix}${(var24h * 100).toFixed(2)}%`];
+    return [createAlert(`📊 Var24h: ${prefix}${(var24h * 100).toFixed(2)}%`, ALERT_LEVELS.LOW)];
 }

--- a/src/alerts/volumeAlert.js
+++ b/src/alerts/volumeAlert.js
@@ -1,3 +1,5 @@
+import { ALERT_LEVELS, createAlert } from './shared.js';
+
 export default function volumeAlert({ volumes, thresholds }) {
     const alerts = [];
     const recent = volumes?.slice(-20);
@@ -7,7 +9,7 @@ export default function volumeAlert({ volumes, thresholds }) {
     if (recent && recent.length === 20 && lastVolume != null && volumeSpike != null) {
         const avg = recent.reduce((sum, value) => sum + value, 0) / recent.length;
         if (lastVolume > volumeSpike * avg) {
-            alerts.push("🔊 Volume spike (>2x avg)");
+            alerts.push(createAlert("🔊 Volume spike (>2x avg)", ALERT_LEVELS.MEDIUM));
         }
     }
 

--- a/src/alerts/vwapAlert.js
+++ b/src/alerts/vwapAlert.js
@@ -1,3 +1,5 @@
+import { ALERT_LEVELS, createAlert } from './shared.js';
+
 export default function vwapAlert({ vwapSeries, closes, lastClose }) {
     const alerts = [];
     const vwap = vwapSeries?.at(-1);
@@ -7,10 +9,10 @@ export default function vwapAlert({ vwapSeries, closes, lastClose }) {
 
     if (vwap != null && price != null && prevPrice != null && prevVwap != null) {
         if (price > vwap && prevPrice <= prevVwap) {
-            alerts.push("📈 Price crossed above VWAP");
+            alerts.push(createAlert("📈 Price crossed above VWAP", ALERT_LEVELS.MEDIUM));
         }
         if (price < vwap && prevPrice >= prevVwap) {
-            alerts.push("📉 Price crossed below VWAP");
+            alerts.push(createAlert("📉 Price crossed below VWAP", ALERT_LEVELS.MEDIUM));
         }
     }
 

--- a/src/alerts/williamsAlert.js
+++ b/src/alerts/williamsAlert.js
@@ -1,13 +1,15 @@
+import { ALERT_LEVELS, createAlert } from './shared.js';
+
 export default function williamsAlert({ willrSeries, thresholds }) {
     const alerts = [];
     const willr = willrSeries?.at(-1);
     const { williamsROverbought, williamsROversold } = thresholds ?? {};
 
     if (willr != null && williamsROverbought != null && willr > williamsROverbought) {
-        alerts.push("📉 Williams %R overbought");
+        alerts.push(createAlert("📉 Williams %R overbought", ALERT_LEVELS.MEDIUM));
     }
     if (willr != null && williamsROversold != null && willr < williamsROversold) {
-        alerts.push("📈 Williams %R oversold");
+        alerts.push(createAlert("📈 Williams %R oversold", ALERT_LEVELS.MEDIUM));
     }
 
     return alerts;

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import { buildSnapshotForReport, buildSummary } from "./reporter.js";
 import { postAnalysis, sendDiscordAlert } from "./discord.js";
 import { postCharts, initBot } from "./discordBot.js";
 import { renderChartPNG } from "./chart.js";
-import { buildAlerts } from "./alerts.js";
+import { buildAlerts, formatAlertMessage } from "./alerts.js";
 import { runAgent } from "./ai.js";
 import { getSignature, updateSignature, saveStore } from "./store.js";
 import { fetchEconomicEvents } from "./data/economic.js";
@@ -212,10 +212,13 @@ async function runOnceForAsset(asset) {
                     riskPct: CFG.riskPerTrade
                 });
                 const hasSignals = alerts.some(a =>
-                    !a.startsWith('💰 Preço') && !a.startsWith('📊 Var24h'));
+                    !a.msg.startsWith('💰 Preço') && !a.msg.startsWith('📊 Var24h'));
                 if (hasSignals) {
                     const mention = "@here";
-                    const alertMsg = [`**⚠️ Alertas — ${asset.key} ${tf}** ${mention}`, ...alerts.map(a => `• ${a}`)].join("\n");
+                    const alertMsg = [
+                        `**⚠️ Alertas — ${asset.key} ${tf}** ${mention}`,
+                        ...alerts.map(alert => `• ${formatAlertMessage(alert)}`)
+                    ].join("\n");
                     const hash = buildHash(alertMsg);
                     const windowMs = CFG.alertDedupMinutes * 60 * 1000;
                     if (shouldSend(hash, windowMs)) {

--- a/tests/alerts-config.test.js
+++ b/tests/alerts-config.test.js
@@ -54,11 +54,11 @@ describe('buildAlerts configuration', () => {
     data.rsiSeries = [65];
 
     const defaultAlerts = await buildAlerts(data);
-    expect(defaultAlerts).not.toContain('📉 RSI>70 (sobrecompra)');
+    expect(defaultAlerts.map(alert => alert.msg)).not.toContain('📉 RSI>70 (sobrecompra)');
 
     CFG.alertThresholds.rsiOverbought = 60;
     const customAlerts = await buildAlerts(data);
-    expect(customAlerts).toContain('📉 RSI>70 (sobrecompra)');
+    expect(customAlerts.map(alert => alert.msg)).toContain('📉 RSI>70 (sobrecompra)');
   });
 
   it('respects configurable volume spike multiplier', async () => {
@@ -66,11 +66,11 @@ describe('buildAlerts configuration', () => {
     data.volumes = Array(20).fill(1000).concat(1500);
 
     const defaultAlerts = await buildAlerts(data);
-    expect(defaultAlerts).not.toContain('🔊 Volume spike (>2x avg)');
+    expect(defaultAlerts.map(alert => alert.msg)).not.toContain('🔊 Volume spike (>2x avg)');
 
     CFG.alertThresholds.volumeSpike = 1.4;
     const customAlerts = await buildAlerts(data);
-    expect(customAlerts).toContain('🔊 Volume spike (>2x avg)');
+    expect(customAlerts.map(alert => alert.msg)).toContain('🔊 Volume spike (>2x avg)');
   });
 });
 


### PR DESCRIPTION
## Summary
- introduce shared alert severity helpers and convert alert modules to emit `{ msg, level }` objects
- sort alerts by severity and add formatted output for Discord and AI reporting
- update alert consumers and tests to cover the new structure and styling

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1bdcb235483269585ddd165137a71