### PR TITLE
Add alert categories and consolidate duplicate messages

### DIFF
--- a/src/alerts/adxAlert.js
+++ b/src/alerts/adxAlert.js
@@ -1,11 +1,11 @@
-import { ALERT_LEVELS, createAlert } from './shared.js';
+import { ALERT_LEVELS, ALERT_CATEGORIES, createAlert } from './shared.js';
 
 export default function adxAlert({ adxSeries, thresholds }) {
     const alerts = [];
     const adx = adxSeries?.at(-1);
     const { adxStrongTrend } = thresholds ?? {};
     if (adx != null && adxStrongTrend != null && adx >= adxStrongTrend) {
-        alerts.push(createAlert("💪 ADX>25 (tendência forte)", ALERT_LEVELS.HIGH));
+        alerts.push(createAlert("💪 ADX>25 (tendência forte)", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.TREND));
     }
     return alerts;
 }

--- a/src/alerts/atrAlert.js
+++ b/src/alerts/atrAlert.js
@@ -1,4 +1,4 @@
-import { ALERT_LEVELS, createAlert } from './shared.js';
+import { ALERT_LEVELS, ALERT_CATEGORIES, createAlert } from './shared.js';
 
 export default function atrAlert({ atrSeries, thresholds }) {
     const alerts = [];
@@ -7,7 +7,7 @@ export default function atrAlert({ atrSeries, thresholds }) {
     const { atrSpike } = thresholds ?? {};
 
     if (atr != null && prevAtr != null && atrSpike != null && atr > atrSpike * prevAtr) {
-        alerts.push(createAlert("⚡ ATR spike (volatility)", ALERT_LEVELS.HIGH));
+        alerts.push(createAlert("⚡ ATR spike (volatility)", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.VOLATILITY));
     }
 
     return alerts;

--- a/src/alerts/bollingerAlert.js
+++ b/src/alerts/bollingerAlert.js
@@ -1,5 +1,5 @@
 import { isBBSqueeze } from '../indicators.js';
-import { ALERT_LEVELS, createAlert } from './shared.js';
+import { ALERT_LEVELS, ALERT_CATEGORIES, createAlert } from './shared.js';
 
 export default function bollingerAlert({ bbWidth, lastClose, upperBB, lowerBB, upperKC, lowerKC }) {
     const alerts = [];
@@ -10,19 +10,19 @@ export default function bollingerAlert({ bbWidth, lastClose, upperBB, lowerBB, u
     const lowerKeltner = lowerKC?.at(-1);
 
     if (Array.isArray(bbWidth) && bbWidth.length > 0 && isBBSqueeze(bbWidth)) {
-        alerts.push(createAlert("🧨 BB squeeze (compressão)", ALERT_LEVELS.MEDIUM));
+        alerts.push(createAlert("🧨 BB squeeze (compressão)", ALERT_LEVELS.MEDIUM, ALERT_CATEGORIES.VOLATILITY));
     }
     if (price != null && upper != null && price > upper) {
-        alerts.push(createAlert("📈 BB breakout above", ALERT_LEVELS.HIGH));
+        alerts.push(createAlert("📈 BB breakout above", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.VOLATILITY));
     }
     if (price != null && lower != null && price < lower) {
-        alerts.push(createAlert("📉 BB breakout below", ALERT_LEVELS.HIGH));
+        alerts.push(createAlert("📉 BB breakout below", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.VOLATILITY));
     }
     if (price != null && upperKeltner != null && price > upperKeltner) {
-        alerts.push(createAlert("📈 KC breakout above", ALERT_LEVELS.HIGH));
+        alerts.push(createAlert("📈 KC breakout above", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.VOLATILITY));
     }
     if (price != null && lowerKeltner != null && price < lowerKeltner) {
-        alerts.push(createAlert("📉 KC breakout below", ALERT_LEVELS.HIGH));
+        alerts.push(createAlert("📉 KC breakout below", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.VOLATILITY));
     }
 
     return alerts;

--- a/src/alerts/cciAlert.js
+++ b/src/alerts/cciAlert.js
@@ -1,4 +1,4 @@
-import { ALERT_LEVELS, createAlert } from './shared.js';
+import { ALERT_LEVELS, ALERT_CATEGORIES, createAlert } from './shared.js';
 
 export default function cciAlert({ cciSeries, thresholds }) {
     const alerts = [];
@@ -6,10 +6,10 @@ export default function cciAlert({ cciSeries, thresholds }) {
     const { cciOverbought, cciOversold } = thresholds ?? {};
 
     if (cci != null && cciOverbought != null && cci > cciOverbought) {
-        alerts.push(createAlert("📉 CCI overbought", ALERT_LEVELS.MEDIUM));
+        alerts.push(createAlert("📉 CCI overbought", ALERT_LEVELS.MEDIUM, ALERT_CATEGORIES.MOMENTUM));
     }
     if (cci != null && cciOversold != null && cci < cciOversold) {
-        alerts.push(createAlert("📈 CCI oversold", ALERT_LEVELS.MEDIUM));
+        alerts.push(createAlert("📈 CCI oversold", ALERT_LEVELS.MEDIUM, ALERT_CATEGORIES.MOMENTUM));
     }
 
     return alerts;

--- a/src/alerts/emaCrossoverAlert.js
+++ b/src/alerts/emaCrossoverAlert.js
@@ -1,4 +1,4 @@
-import { ALERT_LEVELS, createAlert } from './shared.js';
+import { ALERT_LEVELS, ALERT_CATEGORIES, createAlert } from './shared.js';
 
 export default function emaCrossoverAlert({ ema9, ema21 }) {
     const alerts = [];
@@ -9,10 +9,10 @@ export default function emaCrossoverAlert({ ema9, ema21 }) {
 
     if (ema9Val != null && ema21Val != null && prevEma9 != null && prevEma21 != null) {
         if (prevEma9 < prevEma21 && ema9Val > ema21Val) {
-            alerts.push(createAlert("📈 EMA 9/21 bullish crossover", ALERT_LEVELS.HIGH));
+            alerts.push(createAlert("📈 EMA 9/21 bullish crossover", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.TREND));
         }
         if (prevEma9 > prevEma21 && ema9Val < ema21Val) {
-            alerts.push(createAlert("📉 EMA 9/21 bearish crossover", ALERT_LEVELS.HIGH));
+            alerts.push(createAlert("📉 EMA 9/21 bearish crossover", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.TREND));
         }
     }
 

--- a/src/alerts/heuristicAlert.js
+++ b/src/alerts/heuristicAlert.js
@@ -1,4 +1,4 @@
-import { ALERT_LEVELS, createAlert } from './shared.js';
+import { ALERT_LEVELS, ALERT_CATEGORIES, createAlert } from './shared.js';
 
 export default function heuristicAlert({ heuristicSeries, thresholds }) {
     const alerts = [];
@@ -6,10 +6,10 @@ export default function heuristicAlert({ heuristicSeries, thresholds }) {
     const { heuristicHigh, heuristicLow } = thresholds ?? {};
 
     if (heuristic != null && heuristicHigh != null && heuristic > heuristicHigh) {
-        alerts.push(createAlert("🌟 Heuristic score very high", ALERT_LEVELS.HIGH));
+        alerts.push(createAlert("🌟 Heuristic score very high", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.MOMENTUM));
     }
     if (heuristic != null && heuristicLow != null && heuristic < heuristicLow) {
-        alerts.push(createAlert("⚠️ Heuristic score very low", ALERT_LEVELS.HIGH));
+        alerts.push(createAlert("⚠️ Heuristic score very low", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.MOMENTUM));
     }
 
     return alerts;

--- a/src/alerts/highLowAlert.js
+++ b/src/alerts/highLowAlert.js
@@ -1,4 +1,4 @@
-import { ALERT_LEVELS, createAlert } from './shared.js';
+import { ALERT_LEVELS, ALERT_CATEGORIES, createAlert } from './shared.js';
 
 export default function highLowAlert({ highs, lows, lastClose }) {
     const alerts = [];
@@ -9,10 +9,10 @@ export default function highLowAlert({ highs, lows, lastClose }) {
     const minLow = low20 && low20.length ? Math.min(...low20) : undefined;
 
     if (price != null && maxHigh != null && price >= maxHigh) {
-        alerts.push(createAlert("🚀 New 20-period high", ALERT_LEVELS.HIGH));
+        alerts.push(createAlert("🚀 New 20-period high", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.TREND));
     }
     if (price != null && minLow != null && price <= minLow) {
-        alerts.push(createAlert("⚠️ New 20-period low", ALERT_LEVELS.HIGH));
+        alerts.push(createAlert("⚠️ New 20-period low", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.TREND));
     }
 
     return alerts;

--- a/src/alerts/maCrossoverAlert.js
+++ b/src/alerts/maCrossoverAlert.js
@@ -1,5 +1,5 @@
 import { crossUp, crossDown } from '../indicators.js';
-import { ALERT_LEVELS, createAlert } from './shared.js';
+import { ALERT_LEVELS, ALERT_CATEGORIES, createAlert } from './shared.js';
 
 export default function maCrossoverAlert({ ma20, ma50, ma200 }) {
     if (!Array.isArray(ma20) || !Array.isArray(ma50)) {
@@ -8,17 +8,17 @@ export default function maCrossoverAlert({ ma20, ma50, ma200 }) {
 
     const alerts = [];
     if (crossUp(ma20, ma50)) {
-        alerts.push(createAlert("📈 Golden cross 20/50", ALERT_LEVELS.HIGH));
+        alerts.push(createAlert("📈 Golden cross 20/50", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.TREND));
     }
     if (crossDown(ma20, ma50)) {
-        alerts.push(createAlert("📉 Death cross 20/50", ALERT_LEVELS.HIGH));
+        alerts.push(createAlert("📉 Death cross 20/50", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.TREND));
     }
     if (Array.isArray(ma200)) {
         if (crossUp(ma50, ma200)) {
-            alerts.push(createAlert("📈 Golden cross 50/200", ALERT_LEVELS.HIGH));
+            alerts.push(createAlert("📈 Golden cross 50/200", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.TREND));
         }
         if (crossDown(ma50, ma200)) {
-            alerts.push(createAlert("📉 Death cross 50/200", ALERT_LEVELS.HIGH));
+            alerts.push(createAlert("📉 Death cross 50/200", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.TREND));
         }
     }
     return alerts;

--- a/src/alerts/maPriceAlert.js
+++ b/src/alerts/maPriceAlert.js
@@ -1,4 +1,4 @@
-import { ALERT_LEVELS, createAlert } from './shared.js';
+import { ALERT_LEVELS, ALERT_CATEGORIES, createAlert } from './shared.js';
 
 export default function maPriceAlert({ ma20, ma50, ma200, lastClose, closes }) {
     const alerts = [];
@@ -10,26 +10,26 @@ export default function maPriceAlert({ ma20, ma50, ma200, lastClose, closes }) {
 
     if (price != null && prevPrice != null && ma20Val != null) {
         if (price > ma20Val && prevPrice <= ma20Val) {
-            alerts.push(createAlert("📈 Price crossed above MA20", ALERT_LEVELS.MEDIUM));
+            alerts.push(createAlert("📈 Price crossed above MA20", ALERT_LEVELS.MEDIUM, ALERT_CATEGORIES.TREND));
         }
         if (price < ma20Val && prevPrice >= ma20Val) {
-            alerts.push(createAlert("📉 Price crossed below MA20", ALERT_LEVELS.MEDIUM));
+            alerts.push(createAlert("📉 Price crossed below MA20", ALERT_LEVELS.MEDIUM, ALERT_CATEGORIES.TREND));
         }
     }
     if (price != null && prevPrice != null && ma50Val != null) {
         if (price > ma50Val && prevPrice <= ma50Val) {
-            alerts.push(createAlert("📈 Price crossed above MA50", ALERT_LEVELS.MEDIUM));
+            alerts.push(createAlert("📈 Price crossed above MA50", ALERT_LEVELS.MEDIUM, ALERT_CATEGORIES.TREND));
         }
         if (price < ma50Val && prevPrice >= ma50Val) {
-            alerts.push(createAlert("📉 Price crossed below MA50", ALERT_LEVELS.MEDIUM));
+            alerts.push(createAlert("📉 Price crossed below MA50", ALERT_LEVELS.MEDIUM, ALERT_CATEGORIES.TREND));
         }
     }
     if (price != null && prevPrice != null && ma200Val != null) {
         if (price > ma200Val && prevPrice <= ma200Val) {
-            alerts.push(createAlert("📈 Price crossed above MA200", ALERT_LEVELS.HIGH));
+            alerts.push(createAlert("📈 Price crossed above MA200", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.TREND));
         }
         if (price < ma200Val && prevPrice >= ma200Val) {
-            alerts.push(createAlert("📉 Price crossed below MA200", ALERT_LEVELS.HIGH));
+            alerts.push(createAlert("📉 Price crossed below MA200", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.TREND));
         }
     }
 

--- a/src/alerts/macdAlert.js
+++ b/src/alerts/macdAlert.js
@@ -1,5 +1,5 @@
 import { crossUp, crossDown } from '../indicators.js';
-import { ALERT_LEVELS, createAlert } from './shared.js';
+import { ALERT_LEVELS, ALERT_CATEGORIES, createAlert } from './shared.js';
 
 export default function macdAlert({ macdObj }) {
     const alerts = [];
@@ -11,20 +11,20 @@ export default function macdAlert({ macdObj }) {
 
     if (macd != null && macdSignal != null && prevMacd != null && prevSignal != null) {
         if (prevMacd < prevSignal && macd > macdSignal) {
-            alerts.push(createAlert("📈 MACD bullish crossover", ALERT_LEVELS.HIGH));
+            alerts.push(createAlert("📈 MACD bullish crossover", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.MOMENTUM));
         }
         if (prevMacd > prevSignal && macd < macdSignal) {
-            alerts.push(createAlert("📉 MACD bearish crossover", ALERT_LEVELS.HIGH));
+            alerts.push(createAlert("📉 MACD bearish crossover", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.MOMENTUM));
         }
     }
 
     if (macdHist && macdHist.length >= 2) {
         const zeros = Array(macdHist.length).fill(0);
         if (crossUp(macdHist, zeros)) {
-            alerts.push(createAlert("📈 MACD flip ↑", ALERT_LEVELS.MEDIUM));
+            alerts.push(createAlert("📈 MACD flip ↑", ALERT_LEVELS.MEDIUM, ALERT_CATEGORIES.MOMENTUM));
         }
         if (crossDown(macdHist, zeros)) {
-            alerts.push(createAlert("📉 MACD flip ↓", ALERT_LEVELS.MEDIUM));
+            alerts.push(createAlert("📉 MACD flip ↓", ALERT_LEVELS.MEDIUM, ALERT_CATEGORIES.MOMENTUM));
         }
     }
 

--- a/src/alerts/obvAlert.js
+++ b/src/alerts/obvAlert.js
@@ -1,4 +1,4 @@
-import { ALERT_LEVELS, createAlert } from './shared.js';
+import { ALERT_LEVELS, ALERT_CATEGORIES, createAlert } from './shared.js';
 
 export default function obvAlert({ obvSeries, thresholds }) {
     const alerts = [];
@@ -8,10 +8,10 @@ export default function obvAlert({ obvSeries, thresholds }) {
 
     if (obv != null && prevObv != null && obvDelta != null) {
         if (obv > prevObv * (1 + obvDelta)) {
-            alerts.push(createAlert("📈 OBV bullish divergence", ALERT_LEVELS.MEDIUM));
+            alerts.push(createAlert("📈 OBV bullish divergence", ALERT_LEVELS.MEDIUM, ALERT_CATEGORIES.MOMENTUM));
         }
         if (obv < prevObv * (1 - obvDelta)) {
-            alerts.push(createAlert("📉 OBV bearish divergence", ALERT_LEVELS.MEDIUM));
+            alerts.push(createAlert("📉 OBV bearish divergence", ALERT_LEVELS.MEDIUM, ALERT_CATEGORIES.MOMENTUM));
         }
     }
 

--- a/src/alerts/rsiAlert.js
+++ b/src/alerts/rsiAlert.js
@@ -1,4 +1,4 @@
-import { ALERT_LEVELS, createAlert } from './shared.js';
+import { ALERT_LEVELS, ALERT_CATEGORIES, createAlert } from './shared.js';
 
 export default function rsiAlert({ rsiSeries, thresholds }) {
     const alerts = [];
@@ -11,17 +11,17 @@ export default function rsiAlert({ rsiSeries, thresholds }) {
     } = thresholds ?? {};
 
     if (rsi != null && rsiOverbought != null && rsi > rsiOverbought) {
-        alerts.push(createAlert("📉 RSI>70 (sobrecompra)", ALERT_LEVELS.HIGH));
+        alerts.push(createAlert("📉 RSI>70 (sobrecompra)", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.MOMENTUM));
     }
     if (rsi != null && rsiOversold != null && rsi < rsiOversold) {
-        alerts.push(createAlert("📈 RSI<30 (sobrevenda)", ALERT_LEVELS.HIGH));
+        alerts.push(createAlert("📈 RSI<30 (sobrevenda)", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.MOMENTUM));
     }
     if (prevRsi != null && rsi != null) {
         if (rsiOverbought != null && prevRsi > rsiOverbought && rsi <= rsiOverbought) {
-            alerts.push(createAlert("📉 RSI cross-back ↓ (70→<70)", ALERT_LEVELS.MEDIUM));
+            alerts.push(createAlert("📉 RSI cross-back ↓ (70→<70)", ALERT_LEVELS.MEDIUM, ALERT_CATEGORIES.MOMENTUM));
         }
         if (rsiOversold != null && prevRsi < rsiOversold && rsi >= rsiOversold) {
-            alerts.push(createAlert("📈 RSI cross-back ↑ (<30→>30)", ALERT_LEVELS.MEDIUM));
+            alerts.push(createAlert("📈 RSI cross-back ↑ (<30→>30)", ALERT_LEVELS.MEDIUM, ALERT_CATEGORIES.MOMENTUM));
         }
         if (
             rsiOverbought != null && rsiMidpoint != null &&
@@ -29,7 +29,7 @@ export default function rsiAlert({ rsiSeries, thresholds }) {
             rsi < rsiOverbought &&
             rsi >= rsiMidpoint
         ) {
-            alerts.push(createAlert("🔄 RSI neutral (de >70)", ALERT_LEVELS.LOW));
+            alerts.push(createAlert("🔄 RSI neutral (de >70)", ALERT_LEVELS.LOW, ALERT_CATEGORIES.MOMENTUM));
         }
         if (
             rsiOversold != null && rsiMidpoint != null &&
@@ -37,13 +37,13 @@ export default function rsiAlert({ rsiSeries, thresholds }) {
             rsi > rsiOversold &&
             rsi <= rsiMidpoint
         ) {
-            alerts.push(createAlert("🔄 RSI neutral (de <30)", ALERT_LEVELS.LOW));
+            alerts.push(createAlert("🔄 RSI neutral (de <30)", ALERT_LEVELS.LOW, ALERT_CATEGORIES.MOMENTUM));
         }
         if (rsiMidpoint != null && prevRsi < rsiMidpoint && rsi >= rsiMidpoint) {
-            alerts.push(createAlert("📈 RSI crossed 50↑ (momentum shift)", ALERT_LEVELS.MEDIUM));
+            alerts.push(createAlert("📈 RSI crossed 50↑ (momentum shift)", ALERT_LEVELS.MEDIUM, ALERT_CATEGORIES.MOMENTUM));
         }
         if (rsiMidpoint != null && prevRsi > rsiMidpoint && rsi <= rsiMidpoint) {
-            alerts.push(createAlert("📉 RSI crossed 50↓ (momentum shift)", ALERT_LEVELS.MEDIUM));
+            alerts.push(createAlert("📉 RSI crossed 50↓ (momentum shift)", ALERT_LEVELS.MEDIUM, ALERT_CATEGORIES.MOMENTUM));
         }
     }
 

--- a/src/alerts/sarAlert.js
+++ b/src/alerts/sarAlert.js
@@ -1,4 +1,4 @@
-import { ALERT_LEVELS, createAlert } from './shared.js';
+import { ALERT_LEVELS, ALERT_CATEGORIES, createAlert } from './shared.js';
 
 export default function sarAlert({ sarSeries, lastClose }) {
     const alerts = [];
@@ -8,10 +8,10 @@ export default function sarAlert({ sarSeries, lastClose }) {
 
     if (price != null && sar != null && prevSar != null) {
         if (prevSar < price && sar > price) {
-            alerts.push(createAlert("📉 Parabolic SAR flip bearish", ALERT_LEVELS.HIGH));
+            alerts.push(createAlert("📉 Parabolic SAR flip bearish", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.TREND));
         }
         if (prevSar > price && sar < price) {
-            alerts.push(createAlert("📈 Parabolic SAR flip bullish", ALERT_LEVELS.HIGH));
+            alerts.push(createAlert("📈 Parabolic SAR flip bullish", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.TREND));
         }
     }
 

--- a/src/alerts/shared.js
+++ b/src/alerts/shared.js
@@ -4,6 +4,20 @@ export const ALERT_LEVELS = Object.freeze({
     LOW: 'low'
 });
 
-export function createAlert(msg, level = ALERT_LEVELS.MEDIUM) {
-    return { msg, level };
+export const ALERT_CATEGORIES = Object.freeze({
+    TREND: 'trend',
+    MOMENTUM: 'momentum',
+    VOLATILITY: 'volatility',
+    INFO: 'info'
+});
+
+export const ALERT_CATEGORY_LABELS = Object.freeze({
+    [ALERT_CATEGORIES.TREND]: 'Tendência',
+    [ALERT_CATEGORIES.MOMENTUM]: 'Momentum',
+    [ALERT_CATEGORIES.VOLATILITY]: 'Volatilidade',
+    [ALERT_CATEGORIES.INFO]: 'Informação'
+});
+
+export function createAlert(msg, level = ALERT_LEVELS.MEDIUM, category = ALERT_CATEGORIES.INFO) {
+    return { msg, level, category };
 }

--- a/src/alerts/stochasticAlert.js
+++ b/src/alerts/stochasticAlert.js
@@ -1,4 +1,4 @@
-import { ALERT_LEVELS, createAlert } from './shared.js';
+import { ALERT_LEVELS, ALERT_CATEGORIES, createAlert } from './shared.js';
 
 export default function stochasticAlert({ stochasticK, thresholds }) {
     const alerts = [];
@@ -6,10 +6,10 @@ export default function stochasticAlert({ stochasticK, thresholds }) {
     const { stochasticOverbought, stochasticOversold } = thresholds ?? {};
 
     if (stochK != null && stochasticOverbought != null && stochK > stochasticOverbought) {
-        alerts.push(createAlert("📉 Stochastic overbought", ALERT_LEVELS.MEDIUM));
+        alerts.push(createAlert("📉 Stochastic overbought", ALERT_LEVELS.MEDIUM, ALERT_CATEGORIES.MOMENTUM));
     }
     if (stochK != null && stochasticOversold != null && stochK < stochasticOversold) {
-        alerts.push(createAlert("📈 Stochastic oversold", ALERT_LEVELS.MEDIUM));
+        alerts.push(createAlert("📈 Stochastic oversold", ALERT_LEVELS.MEDIUM, ALERT_CATEGORIES.MOMENTUM));
     }
 
     return alerts;

--- a/src/alerts/trendAlert.js
+++ b/src/alerts/trendAlert.js
@@ -1,13 +1,13 @@
-import { ALERT_LEVELS, createAlert } from './shared.js';
+import { ALERT_LEVELS, ALERT_CATEGORIES, createAlert } from './shared.js';
 
 export default function trendAlert({ trendSeries }) {
     const alerts = [];
     const trend = trendSeries?.at(-1);
     if (trend === 1) {
-        alerts.push(createAlert("📈 Strong uptrend", ALERT_LEVELS.HIGH));
+        alerts.push(createAlert("📈 Strong uptrend", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.TREND));
     }
     if (trend === -1) {
-        alerts.push(createAlert("📉 Strong downtrend", ALERT_LEVELS.HIGH));
+        alerts.push(createAlert("📉 Strong downtrend", ALERT_LEVELS.HIGH, ALERT_CATEGORIES.TREND));
     }
     return alerts;
 }

--- a/src/alerts/varAlert.js
+++ b/src/alerts/varAlert.js
@@ -1,9 +1,9 @@
-import { ALERT_LEVELS, createAlert } from './shared.js';
+import { ALERT_LEVELS, ALERT_CATEGORIES, createAlert } from './shared.js';
 
 export default function varAlert({ var24h }) {
     if (var24h == null) {
         return [];
     }
     const prefix = var24h > 0 ? '+' : '';
-    return [createAlert(`📊 Var24h: ${prefix}${(var24h * 100).toFixed(2)}%`, ALERT_LEVELS.LOW)];
+    return [createAlert(`📊 Var24h: ${prefix}${(var24h * 100).toFixed(2)}%`, ALERT_LEVELS.LOW, ALERT_CATEGORIES.VOLATILITY)];
 }

--- a/src/alerts/volumeAlert.js
+++ b/src/alerts/volumeAlert.js
@@ -1,4 +1,4 @@
-import { ALERT_LEVELS, createAlert } from './shared.js';
+import { ALERT_LEVELS, ALERT_CATEGORIES, createAlert } from './shared.js';
 
 export default function volumeAlert({ volumes, thresholds }) {
     const alerts = [];
@@ -9,7 +9,7 @@ export default function volumeAlert({ volumes, thresholds }) {
     if (recent && recent.length === 20 && lastVolume != null && volumeSpike != null) {
         const avg = recent.reduce((sum, value) => sum + value, 0) / recent.length;
         if (lastVolume > volumeSpike * avg) {
-            alerts.push(createAlert("🔊 Volume spike (>2x avg)", ALERT_LEVELS.MEDIUM));
+            alerts.push(createAlert("🔊 Volume spike (>2x avg)", ALERT_LEVELS.MEDIUM, ALERT_CATEGORIES.VOLATILITY));
         }
     }
 

--- a/src/alerts/vwapAlert.js
+++ b/src/alerts/vwapAlert.js
@@ -1,4 +1,4 @@
-import { ALERT_LEVELS, createAlert } from './shared.js';
+import { ALERT_LEVELS, ALERT_CATEGORIES, createAlert } from './shared.js';
 
 export default function vwapAlert({ vwapSeries, closes, lastClose }) {
     const alerts = [];
@@ -9,10 +9,10 @@ export default function vwapAlert({ vwapSeries, closes, lastClose }) {
 
     if (vwap != null && price != null && prevPrice != null && prevVwap != null) {
         if (price > vwap && prevPrice <= prevVwap) {
-            alerts.push(createAlert("📈 Price crossed above VWAP", ALERT_LEVELS.MEDIUM));
+            alerts.push(createAlert("📈 Price crossed above VWAP", ALERT_LEVELS.MEDIUM, ALERT_CATEGORIES.MOMENTUM));
         }
         if (price < vwap && prevPrice >= prevVwap) {
-            alerts.push(createAlert("📉 Price crossed below VWAP", ALERT_LEVELS.MEDIUM));
+            alerts.push(createAlert("📉 Price crossed below VWAP", ALERT_LEVELS.MEDIUM, ALERT_CATEGORIES.MOMENTUM));
         }
     }
 

--- a/src/alerts/williamsAlert.js
+++ b/src/alerts/williamsAlert.js
@@ -1,4 +1,4 @@
-import { ALERT_LEVELS, createAlert } from './shared.js';
+import { ALERT_LEVELS, ALERT_CATEGORIES, createAlert } from './shared.js';
 
 export default function williamsAlert({ willrSeries, thresholds }) {
     const alerts = [];
@@ -6,10 +6,10 @@ export default function williamsAlert({ willrSeries, thresholds }) {
     const { williamsROverbought, williamsROversold } = thresholds ?? {};
 
     if (willr != null && williamsROverbought != null && willr > williamsROverbought) {
-        alerts.push(createAlert("📉 Williams %R overbought", ALERT_LEVELS.MEDIUM));
+        alerts.push(createAlert("📉 Williams %R overbought", ALERT_LEVELS.MEDIUM, ALERT_CATEGORIES.MOMENTUM));
     }
     if (willr != null && williamsROversold != null && willr < williamsROversold) {
-        alerts.push(createAlert("📈 Williams %R oversold", ALERT_LEVELS.MEDIUM));
+        alerts.push(createAlert("📈 Williams %R oversold", ALERT_LEVELS.MEDIUM, ALERT_CATEGORIES.MOMENTUM));
     }
 
     return alerts;


### PR DESCRIPTION
## Summary
- add alert categories with labels so alerts can flag trend, momentum, or volatility context
- ensure all alert modules tag their category and update formatting to display the label and duplicate counts
- consolidate identical alert messages per asset run before sending to Discord to avoid spam

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1c0ecca98832690ea23d38eab14dc