### PR TITLE
Scope alert cache by asset and timeframe

### DIFF
--- a/src/alertCache.js
+++ b/src/alertCache.js
@@ -26,13 +26,13 @@ export function buildHash(text) {
     return crypto.createHash('sha256').update(text).digest('hex');
 }
 
-export function shouldSend(hash, windowMs) {
+export function shouldSend({ asset, tf, hash }, windowMs) {
     const now = Date.now();
     cache = cache.filter(entry => now - entry.time <= windowMs);
-    if (cache.some(entry => entry.hash === hash)) {
+    if (cache.some(entry => entry.hash === hash && entry.asset === asset && entry.tf === tf)) {
         return false;
     }
-    cache.push({ hash, time: now });
+    cache.push({ asset, tf, hash, time: now });
     persist();
     return true;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -234,7 +234,7 @@ async function runOnceForAsset(asset) {
                     ].join("\n");
                     const hash = buildHash(alertMsg);
                     const windowMs = CFG.alertDedupMinutes * 60 * 1000;
-                    if (shouldSend(hash, windowMs)) {
+                    if (shouldSend({ asset: asset.key, tf, hash }, windowMs)) {
                         await sendDiscordAlert(alertMsg);
                     }
                 }

--- a/tests/alertCache.test.js
+++ b/tests/alertCache.test.js
@@ -25,9 +25,21 @@ describe('alertCache', () => {
     const text = 'duplicate alert';
     const hash = buildHash(text);
     const windowMs = 60 * 1000;
-    expect(shouldSend(hash, windowMs)).toBe(true);
-    expect(shouldSend(hash, windowMs)).toBe(false);
+    expect(shouldSend({ asset: 'BTCUSDT', tf: '1h', hash }, windowMs)).toBe(true);
+    expect(shouldSend({ asset: 'BTCUSDT', tf: '1h', hash }, windowMs)).toBe(false);
     vi.advanceTimersByTime(windowMs + 1);
-    expect(shouldSend(hash, windowMs)).toBe(true);
+    expect(shouldSend({ asset: 'BTCUSDT', tf: '1h', hash }, windowMs)).toBe(true);
+  });
+
+  it('allows same hash for different assets and timeframes', () => {
+    const text = 'differentiated alert';
+    const hash = buildHash(text);
+    const windowMs = 60 * 1000;
+
+    expect(shouldSend({ asset: 'BTCUSDT', tf: '1h', hash }, windowMs)).toBe(true);
+    expect(shouldSend({ asset: 'ETHUSDT', tf: '1h', hash }, windowMs)).toBe(true);
+    expect(shouldSend({ asset: 'BTCUSDT', tf: '4h', hash }, windowMs)).toBe(true);
+
+    expect(shouldSend({ asset: 'BTCUSDT', tf: '1h', hash }, windowMs)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- scope alert cache entries by asset and timeframe to avoid cross-asset deduplication
- update alert dispatch to pass asset and timeframe to the cache when checking whether to send
- add tests covering per-asset/timeframe deduplication behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1c56833988326815b4476a52e8ce8