### PR TITLE
Add status command for watchlist and uptime

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ This project posts crypto analysis, charts and alerts to Discord.
   npm run once
   ```
 
+## Discord Commands
+
+- `/chart` – gera um gráfico para o ativo e timeframe informados.
+- `/watch` – adiciona ou remove ativos da watchlist (subcomandos `add` e `remove`).
+- `/status` – mostra o uptime atual do bot e a lista de ativos monitorados.
+
 ## Housekeeping
 
 - Alert deduplication entries older than seven days are pruned automatically once per day. The pruning job also runs on start-up so long-running processes and ephemeral runs stay in sync.

--- a/tests/discordBot.test.js
+++ b/tests/discordBot.test.js
@@ -24,10 +24,11 @@ const fetchOHLCV = vi.fn();
 const renderChartPNG = vi.fn();
 const addAssetToWatch = vi.fn();
 const removeAssetFromWatch = vi.fn();
+const getWatchlist = vi.fn(() => []);
 
 vi.mock('../src/data/binance.js', () => ({ fetchOHLCV }));
 vi.mock('../src/chart.js', () => ({ renderChartPNG }));
-vi.mock('../src/watchlist.js', () => ({ addAssetToWatch, removeAssetFromWatch }));
+vi.mock('../src/watchlist.js', () => ({ addAssetToWatch, removeAssetFromWatch, getWatchlist }));
 
 // environment setup for assets
 process.env.BINANCE_SYMBOL_BTC = 'BTCUSDT';
@@ -113,6 +114,25 @@ describe('discord bot interactions', () => {
     expect(removeAssetFromWatch).toHaveBeenCalledWith('BTC');
     expect(interaction.reply).toHaveBeenCalledWith({
       content: 'Ativo BTC removido da watchlist',
+      ephemeral: true,
+    });
+  });
+
+  it('handles /status command', async () => {
+    getWatchlist.mockReturnValue(['BTC', 'ETH']);
+    const { handleInteraction } = await loadBot();
+
+    const interaction = {
+      isChatInputCommand: () => true,
+      commandName: 'status',
+      reply: vi.fn(),
+    };
+
+    await handleInteraction(interaction);
+
+    expect(getWatchlist).toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: expect.stringContaining('BTC, ETH'),
       ephemeral: true,
     });
   });


### PR DESCRIPTION
## Summary
- add a `/status` slash command that reports the bot uptime and current watchlist
- document available Discord commands in the README
- cover the new command in the Discord bot tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1cc5db2888326a4fdc8ede19688ae