### PR TITLE
Refactor watchlist to store entries per user

### DIFF
--- a/src/discordBot.js
+++ b/src/discordBot.js
@@ -8,8 +8,8 @@ import { addAssetToWatch, removeAssetFromWatch, getWatchlist as loadWatchlist } 
 
 const startTime = Date.now();
 
-function getWatchlist() {
-    return loadWatchlist();
+function getWatchlist(userId) {
+    return loadWatchlist(userId);
 }
 
 function formatUptime(ms) {
@@ -76,16 +76,21 @@ export async function handleInteraction(interaction) {
             return;
         }
         let msg;
+        const userId = interaction.user?.id;
+        if (!userId) {
+            await interaction.reply({ content: 'Não foi possível identificar o usuário.', ephemeral: true });
+            return;
+        }
         if (sub === 'add') {
-            const added = addAssetToWatch(assetKey);
+            const added = addAssetToWatch(userId, assetKey);
             msg = added ? `Ativo ${assetKey} adicionado à watchlist` : `Ativo ${assetKey} já estava na watchlist`;
         } else {
-            const removed = removeAssetFromWatch(assetKey);
+            const removed = removeAssetFromWatch(userId, assetKey);
             msg = removed ? `Ativo ${assetKey} removido da watchlist` : `Ativo ${assetKey} não estava na watchlist`;
         }
         await interaction.reply({ content: msg, ephemeral: true });
     } else if (interaction.commandName === 'status') {
-        const list = getWatchlist();
+        const list = getWatchlist(interaction.user?.id);
         const watchlistText = list.length ? list.join(', ') : 'Nenhum ativo monitorado';
         const uptimeText = formatUptime(Date.now() - startTime);
         const content = `⏱️ Uptime: ${uptimeText}\n👀 Watchlist: ${watchlistText}`;

--- a/tests/discordBot.test.js
+++ b/tests/discordBot.test.js
@@ -83,12 +83,13 @@ describe('discord bot interactions', () => {
         getSubcommand: () => 'add',
         getString: () => 'BTC',
       },
+      user: { id: 'user-1' },
       reply: vi.fn(),
     };
 
     await handleInteraction(interaction);
 
-    expect(addAssetToWatch).toHaveBeenCalledWith('BTC');
+    expect(addAssetToWatch).toHaveBeenCalledWith('user-1', 'BTC');
     expect(interaction.reply).toHaveBeenCalledWith({
       content: 'Ativo BTC adicionado à watchlist',
       ephemeral: true,
@@ -106,12 +107,13 @@ describe('discord bot interactions', () => {
         getSubcommand: () => 'remove',
         getString: () => 'BTC',
       },
+      user: { id: 'user-1' },
       reply: vi.fn(),
     };
 
     await handleInteraction(interaction);
 
-    expect(removeAssetFromWatch).toHaveBeenCalledWith('BTC');
+    expect(removeAssetFromWatch).toHaveBeenCalledWith('user-1', 'BTC');
     expect(interaction.reply).toHaveBeenCalledWith({
       content: 'Ativo BTC removido da watchlist',
       ephemeral: true,
@@ -125,12 +127,13 @@ describe('discord bot interactions', () => {
     const interaction = {
       isChatInputCommand: () => true,
       commandName: 'status',
+      user: { id: 'user-5' },
       reply: vi.fn(),
     };
 
     await handleInteraction(interaction);
 
-    expect(getWatchlist).toHaveBeenCalled();
+    expect(getWatchlist).toHaveBeenCalledWith('user-5');
     expect(interaction.reply).toHaveBeenCalledWith({
       content: expect.stringContaining('BTC, ETH'),
       ephemeral: true,


### PR DESCRIPTION
## Summary
- update watchlist persistence to store assets keyed by Discord user IDs and migrate legacy array data on startup
- adjust Discord bot commands to use the calling user's ID when managing and showing watchlists
- extend unit tests to cover the per-user watchlist behavior and legacy data migration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1cfcaa8ac832680043767d444506d