### PR TITLE
Add slash command to update risk per trade

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -1,0 +1,87 @@
+import fs from 'fs';
+import path from 'path';
+
+const DATA_DIR = path.resolve(process.cwd(), 'data');
+const SETTINGS_FILE = process.env.SETTINGS_FILE
+    ? path.resolve(process.env.SETTINGS_FILE)
+    : path.join(DATA_DIR, 'settings.json');
+
+let settings = {};
+let loaded = false;
+
+function mergeDefaults(defaults) {
+    if (!defaults || typeof defaults !== 'object') {
+        return;
+    }
+    settings = { ...defaults, ...settings };
+}
+
+function persist() {
+    const dir = path.dirname(SETTINGS_FILE);
+    fs.mkdirSync(dir, { recursive: true });
+    const keys = Object.keys(settings);
+    if (keys.length === 0) {
+        if (fs.existsSync(SETTINGS_FILE)) {
+            fs.rmSync(SETTINGS_FILE);
+        }
+        return;
+    }
+    fs.writeFileSync(SETTINGS_FILE, JSON.stringify(settings, null, 2));
+}
+
+export function loadSettings(defaults = {}) {
+    if (!loaded) {
+        settings = {};
+        try {
+            if (fs.existsSync(SETTINGS_FILE)) {
+                const raw = fs.readFileSync(SETTINGS_FILE, 'utf8');
+                const parsed = JSON.parse(raw || '{}');
+                if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+                    settings = { ...parsed };
+                }
+            } else {
+                fs.mkdirSync(path.dirname(SETTINGS_FILE), { recursive: true });
+            }
+        } catch (err) {
+            settings = {};
+        }
+        loaded = true;
+    }
+    mergeDefaults(defaults);
+    return settings;
+}
+
+export function getSettings() {
+    if (!loaded) {
+        loadSettings();
+    }
+    return settings;
+}
+
+export function getSetting(key, fallback) {
+    if (!loaded) {
+        loadSettings();
+    }
+    return key in settings ? settings[key] : fallback;
+}
+
+export function setSetting(key, value) {
+    if (!loaded) {
+        loadSettings();
+    }
+    if (value === undefined) {
+        delete settings[key];
+    } else {
+        settings[key] = value;
+    }
+    persist();
+    return settings[key];
+}
+
+export function resetSettings() {
+    settings = {};
+    loaded = true;
+    if (fs.existsSync(SETTINGS_FILE)) {
+        fs.rmSync(SETTINGS_FILE);
+    }
+}


### PR DESCRIPTION
## Summary
- add a persistent settings module to store runtime configuration overrides
- load a validated risk-per-trade setting from disk when building the config
- expose a `/settings risk percent` slash command to update the stored risk percentage within 0–5%

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d1d0c82cf48326ac1dcec7bdf10a27