### PR TITLE
Add FAQ sections for crypto alert terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,3 +125,17 @@ Todos os módulos utilizam `alertCache` para evitar duplicidade e respeitam conf
 - [Guia da API Spot Binance](https://binance-docs.github.io/apidocs/spot/en/)
 
 O bot registra avisos quando webhooks obrigatórios não estão configurados e interrompe execuções críticas, garantindo falhas rápidas em ambientes de produção.
+
+## FAQ
+
+### O que é este crypto trading bot?
+
+É uma automação que coleta dados de exchanges, calcula indicadores técnicos e envia decisões recomendadas diretamente para o seu servidor. Apesar de não executar ordens por você, o crypto trading bot concentra insights prontos para orientar entradas, saídas e estratégias diárias.
+
+### Como funcionam os Discord alerts do projeto?
+
+Os módulos de alertas monitoram variações de preço, volume e sentimento em tempo real. Quando uma condição configurada é disparada, o bot gera Discord alerts com gráficos, texto e links relevantes no canal escolhido, mantendo todo o time informado sem precisar abrir dashboards externos.
+
+### Posso personalizar indicadores e frequência dos envios?
+
+Sim. Ajuste os indicadores ativos, thresholds e cadência diretamente nos arquivos de configuração ou variáveis de ambiente. Assim, os avisos chegam de acordo com o perfil de risco desejado, seja para acompanhar scalps, swing trades ou relatórios semanais para a comunidade.

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -32,3 +32,17 @@ description: Visão geral do Crypto Daily Discord Bot com destaques das funciona
 
 - Abra uma [issue no GitHub](https://github.com/OWNER/crypto-daily-discord-bot/issues) ou participe das discussões para compartilhar ideias e feedbacks.
 - Customize o cartão social com SVG próprio ou siga o [roteiro de geração de arte com IA](./guide/identidade-visual.md).
+
+## FAQ
+
+### O que torna este crypto trading bot essencial para a comunidade?
+
+Ele automatiza a coleta de dados, o cálculo de indicadores e a curadoria de insights relevantes para decisões rápidas. O crypto trading bot entrega um panorama diário consistente, evitando que os analistas precisem alternar entre múltiplas telas.
+
+### Como os Discord alerts são enviados?
+
+Os módulos de alerta monitoram preço, volume, sentimento e indicadores compostos. Assim que uma condição configurada acontece, o bot envia Discord alerts com gráficos, resumos e links de apoio diretamente para os canais definidos.
+
+### Posso adaptar as notificações para diferentes times?
+
+Sim. Ajuste configurações, webhooks e cadência de cada módulo para adequar o fluxo a scalpers, swing traders ou gestores que desejam relatórios diários e semanais agregados.


### PR DESCRIPTION
## Summary
- add an FAQ to the README destacando crypto trading bot e Discord alerts
- mirror the FAQ section on the VitePress homepage for consistency entre README e site

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d3a7af42848326b09835fb5799fca7