### PR TITLE
Add Discord-ready portfolio growth summaries

### DIFF
--- a/WISHLIST.md
+++ b/WISHLIST.md
@@ -1,10 +1,10 @@
 # Wish List
 
 [] on discord user can see binance account (assets, positions, etc)
-[] on discord user can set minimum profit value
-[] on "alerts" you should consider the variation for each timeframe
-[] on "alerts" you should sort by asset
-[] on "alerts" ypu should have a clear line saying buy/sell/hold
-[] the bot should interact with binance to open and close position/or bear/bull market (margin/assets)
-[] the bot should predict next timeframe close price and keep that values and create a chart for each asset with the values for each timeframe
-[] the bot should consider 100euros initial value and wants to tuner it to 10Million
+[x] on discord user can set minimum profit value
+[x] on "alerts" you should consider the variation for each timeframe
+[x] on "alerts" you should sort by asset
+[x] on "alerts" ypu should have a clear line saying buy/sell/hold
+[x] the bot should interact with binance to open and close position/or bear/bull market (margin/assets)
+[x] the bot should predict next timeframe close price and keep that values and create a chart for each asset with the values for each timeframe
+[x] the bot should consider 100euros initial value and wants to tuner it to 10Million

--- a/config/default.json
+++ b/config/default.json
@@ -30,6 +30,7 @@
   "enableAlerts": true,
   "enableAnalysis": true,
   "enableReports": true,
+  "enableBinanceCommand": true,
   "debug": false,
   "accountEquity": 0,
   "riskPerTrade": 0.01,
@@ -53,6 +54,20 @@
       "asset": "USDT",
       "minFree": 50,
       "transferAmount": 25
+    },
+    "automation": {
+      "enabled": false,
+      "timeframe": "4h",
+      "minConfidence": 0.55,
+      "positionPct": 0.05,
+      "maxPositions": 3,
+      "positionEpsilon": 0.0001,
+      "mode": "margin",
+      "quoteAsset": "USDT",
+      "margin": {
+        "borrowOnShort": true,
+        "repayOnClose": true
+      }
     }
   },
   "marketPosture": {
@@ -95,24 +110,32 @@
       "intervalDays": 30,
       "tolerancePct": 0.05
     },
-    "risk": {
-      "maxDrawdownPct": 0.35,
-      "stopLossPct": 0.12,
-      "takeProfitPct": 0.25,
-      "maxPositionPct": 0.4,
-      "volatilityLookback": 30,
-      "volatilityTargetPct": 0.15
-    },
-    "reporting": {
-      "enabled": true,
-      "directory": "reports/growth",
-      "chartDirectory": "charts/growth",
-      "appendToUploads": false
-    },
-    "strategies": {
-      "default": {
-        "name": "Base Rebalance",
-        "allocation": {
+  "risk": {
+    "maxDrawdownPct": 0.35,
+    "stopLossPct": 0.12,
+    "takeProfitPct": 0.25,
+    "maxPositionPct": 0.4,
+    "volatilityLookback": 30,
+    "volatilityTargetPct": 0.15
+  },
+  "reporting": {
+    "enabled": true,
+    "directory": "reports/growth",
+    "chartDirectory": "charts/growth",
+    "appendToUploads": false
+  },
+  "discord": {
+    "enabled": false,
+    "mention": "",
+    "webhookUrl": "",
+    "channelId": "",
+    "locale": "pt-PT",
+    "includeReportLinks": true
+  },
+  "strategies": {
+    "default": {
+      "name": "Base Rebalance",
+      "allocation": {
           "BTC": 0.45,
           "ETH": 0.3,
           "SOL": 0.15,

--- a/src/alerts/decision.js
+++ b/src/alerts/decision.js
@@ -1,0 +1,127 @@
+export const DECISION_LABELS = Object.freeze({
+    BUY: "buy",
+    SELL: "sell",
+    HOLD: "hold",
+});
+
+function sanitizeAction(action) {
+    if (typeof action !== "string") {
+        return null;
+    }
+    const normalized = action.toLowerCase();
+    if (normalized === "long" || normalized === "buy") {
+        return DECISION_LABELS.BUY;
+    }
+    if (normalized === "short" || normalized === "sell") {
+        return DECISION_LABELS.SELL;
+    }
+    if (normalized === "flat" || normalized === "hold") {
+        return DECISION_LABELS.HOLD;
+    }
+    return null;
+}
+
+function sanitizePosture(posture) {
+    if (typeof posture !== "string") {
+        return null;
+    }
+    return posture.toLowerCase();
+}
+
+function toFinite(value) {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+function pickReasons(candidate) {
+    if (Array.isArray(candidate) && candidate.length > 0) {
+        return candidate.filter(item => typeof item === "string" && item.trim().length > 0);
+    }
+    return [];
+}
+
+export function deriveDecisionDetails({ strategy, posture } = {}) {
+    const actionLabel = sanitizeAction(strategy?.action) ?? sanitizeAction(posture?.posture);
+    const decision = actionLabel ?? DECISION_LABELS.HOLD;
+
+    let emoji = "🟡";
+    if (decision === DECISION_LABELS.BUY) {
+        emoji = "🟢";
+    } else if (decision === DECISION_LABELS.SELL) {
+        emoji = "🔴";
+    }
+
+    const inferredPosture = sanitizePosture(strategy?.posture) ?? sanitizePosture(posture?.posture);
+    const confidence = toFinite(strategy?.confidence) ?? toFinite(posture?.confidence);
+    const reasons = pickReasons(strategy?.reasons);
+    const fallbackReasons = reasons.length > 0 ? reasons : pickReasons(posture?.reasons);
+
+    return {
+        decision,
+        emoji,
+        posture: inferredPosture,
+        confidence,
+        reasons: fallbackReasons,
+    };
+}
+
+function formatConfidence(confidence) {
+    if (!Number.isFinite(confidence)) {
+        return null;
+    }
+    return `${(confidence * 100).toFixed(0)}%`;
+}
+
+function formatPosture(posture) {
+    if (typeof posture !== "string" || posture.length === 0) {
+        return null;
+    }
+    if (posture === "bullish") {
+        return "tendência de alta";
+    }
+    if (posture === "bearish") {
+        return "tendência de baixa";
+    }
+    if (posture === "neutral") {
+        return "neutra";
+    }
+    return posture;
+}
+
+export function formatDecisionLine(details) {
+    if (!details) {
+        return null;
+    }
+    const { decision, emoji, posture, confidence, reasons } = details;
+    if (typeof decision !== "string") {
+        return null;
+    }
+
+    const label = decision.toUpperCase();
+    const segments = [`${emoji} ${label}`];
+
+    const postureLabel = formatPosture(posture);
+    if (postureLabel) {
+        segments.push(`postura ${postureLabel}`);
+    }
+
+    const confidenceLabel = formatConfidence(confidence);
+    if (confidenceLabel) {
+        segments.push(`confiança ${confidenceLabel}`);
+    }
+
+    if (Array.isArray(reasons) && reasons.length > 0) {
+        segments.push(`motivos: ${reasons.slice(0, 2).join(", ")}`);
+    }
+
+    return segments.join(" — ");
+}
+
+export const __private__ = {
+    sanitizeAction,
+    sanitizePosture,
+    toFinite,
+    pickReasons,
+    formatConfidence,
+    formatPosture,
+};

--- a/src/alerts/dispatcher.js
+++ b/src/alerts/dispatcher.js
@@ -1,4 +1,55 @@
+import { ASSETS } from "../assets.js";
+
 const queue = [];
+
+/**
+ * Builds a lookup map with optional market cap ranks for configured assets so
+ * dispatch ordering can prioritise the most relevant markets before falling
+ * back to alphabetical sorting.
+ */
+const assetMetadata = (() => {
+    const metadata = new Map();
+    for (const asset of ASSETS) {
+        if (!asset || typeof asset.key !== "string") {
+            continue;
+        }
+        const normalizedKey = asset.key;
+        const rank = Number.isFinite(asset.marketCapRank) ? asset.marketCapRank : null;
+        metadata.set(normalizedKey, {
+            key: normalizedKey,
+            rank,
+        });
+    }
+    return metadata;
+})();
+
+/**
+ * Compares two asset identifiers, preferring their market cap ranking when
+ * available and gracefully degrading to an alphabetical comparison. Unknown
+ * assets (for example, synthetic or ad-hoc tickers) are also sorted
+ * alphabetically to keep the dispatch flow deterministic.
+ */
+function compareAssets(assetA, assetB) {
+    const keyA = typeof assetA === "string" ? assetA : "";
+    const keyB = typeof assetB === "string" ? assetB : "";
+    const metaA = assetMetadata.get(keyA);
+    const metaB = assetMetadata.get(keyB);
+
+    const rankA = metaA?.rank;
+    const rankB = metaB?.rank;
+    if (Number.isFinite(rankA) && Number.isFinite(rankB) && rankA !== rankB) {
+        return rankA - rankB;
+    }
+    if (Number.isFinite(rankA) && !Number.isFinite(rankB)) {
+        return -1;
+    }
+    if (!Number.isFinite(rankA) && Number.isFinite(rankB)) {
+        return 1;
+    }
+    const labelA = metaA?.key ?? keyA;
+    const labelB = metaB?.key ?? keyB;
+    return labelA.localeCompare(labelB);
+}
 
 function timeframeRank(orderMap, timeframe) {
     if (!timeframe || !orderMap.has(timeframe)) {
@@ -23,9 +74,7 @@ export async function flushAlertQueue({ sender, timeframeOrder = [] } = {}) {
     const handler = typeof sender === "function" ? sender : async () => {};
 
     queue.sort((a, b) => {
-        const assetA = a.asset ?? "";
-        const assetB = b.asset ?? "";
-        const assetCompare = assetA.localeCompare(assetB);
+        const assetCompare = compareAssets(a.asset, b.asset);
         if (assetCompare !== 0) {
             return assetCompare;
         }

--- a/src/alerts/tradeLevelsAlert.js
+++ b/src/alerts/tradeLevelsAlert.js
@@ -1,5 +1,13 @@
 import { atrStopTarget, positionSize } from '../trading/risk.js';
 import { ALERT_LEVELS, createAlert } from './shared.js';
+import { computeTargetProfit, getDefaultMinimumProfitThreshold } from '../minimumProfit.js';
+
+function formatPercent(value) {
+    if (!Number.isFinite(value)) {
+        return '0.00';
+    }
+    return value % 1 === 0 ? value.toFixed(0) : value.toFixed(2);
+}
 
 export default function tradeLevelsAlert({ lastClose, atrSeries, equity, riskPct }) {
     const alerts = [];
@@ -10,10 +18,24 @@ export default function tradeLevelsAlert({ lastClose, atrSeries, equity, riskPct
         const { stop, target } = atrStopTarget(price, atr);
         const size = positionSize(equity, riskPct, price, stop);
         if (stop != null && target != null && Number.isFinite(size)) {
-            alerts.push(createAlert(
-                `🎯 Stop ${stop.toFixed(4)} / Target ${target.toFixed(4)} / Size ${size.toFixed(4)}`,
-                ALERT_LEVELS.LOW
-            ));
+            const profitRatio = computeTargetProfit(price, target);
+            const threshold = getDefaultMinimumProfitThreshold();
+            const profitPercent = Number.isFinite(profitRatio) ? profitRatio * 100 : null;
+            const thresholdPercent = Number.isFinite(threshold) ? threshold * 100 : 0;
+            const profitText = formatPercent(profitPercent ?? 0);
+            const thresholdText = formatPercent(thresholdPercent);
+            const baseMessage = `Stop ${stop.toFixed(4)} / Target ${target.toFixed(4)} / Size ${size.toFixed(4)}`;
+            if (Number.isFinite(profitRatio) && profitRatio < threshold) {
+                alerts.push(createAlert(
+                    `⚠️ ${baseMessage} — Lucro potencial ${profitText}% abaixo do mínimo ${thresholdText}%`,
+                    ALERT_LEVELS.LOW
+                ));
+            } else {
+                alerts.push(createAlert(
+                    `🎯 ${baseMessage} — Lucro potencial ${profitText}% (mínimo ${thresholdText}%)`,
+                    ALERT_LEVELS.LOW
+                ));
+            }
         }
     }
 

--- a/src/alerts/varAlert.js
+++ b/src/alerts/varAlert.js
@@ -1,4 +1,5 @@
 import { ALERT_LEVELS, ALERT_CATEGORIES, createAlert } from "./shared.js";
+import { HIGHER_TIMEFRAME_METRICS } from "./variationMetrics.js";
 
 function formatPercent(value) {
     if (!Number.isFinite(value)) {
@@ -8,17 +9,71 @@ function formatPercent(value) {
     return `${sign}${(value * 100).toFixed(2)}%`;
 }
 
-export default function varAlert({ var24h, timeframe, timeframeVariation }) {
-    const alerts = [];
-    const formattedTimeframe = formatPercent(timeframeVariation);
-    if (timeframe && formattedTimeframe) {
-        alerts.push(createAlert(`📊 Var${timeframe}: ${formattedTimeframe}`, ALERT_LEVELS.LOW, ALERT_CATEGORIES.VOLATILITY));
-    }
+function sortLabels(labels, timeframeOrder = []) {
+    const order = new Map();
+    timeframeOrder.forEach((tf, index) => {
+        if (!order.has(tf)) {
+            order.set(tf, index);
+        }
+    });
+    const baseIndex = order.size;
+    HIGHER_TIMEFRAME_METRICS.forEach((label, index) => {
+        if (!order.has(label)) {
+            order.set(label, baseIndex + index);
+        }
+    });
 
-    const formatted24h = formatPercent(var24h);
-    if (formatted24h) {
-        alerts.push(createAlert(`📊 Var24h: ${formatted24h}`, ALERT_LEVELS.LOW, ALERT_CATEGORIES.VOLATILITY));
-    }
-
-    return alerts;
+    return [...labels].sort((a, b) => {
+        const rankA = order.has(a) ? order.get(a) : Number.MAX_SAFE_INTEGER;
+        const rankB = order.has(b) ? order.get(b) : Number.MAX_SAFE_INTEGER;
+        if (rankA !== rankB) {
+            return rankA - rankB;
+        }
+        return a.localeCompare(b);
+    });
 }
+
+function sanitizeMetrics({ variationByTimeframe, timeframe, timeframeVariation, var24h }) {
+    const metrics = {};
+    for (const [label, value] of Object.entries(variationByTimeframe ?? {})) {
+        if (Number.isFinite(value) && !Object.prototype.hasOwnProperty.call(metrics, label)) {
+            metrics[label] = value;
+        }
+    }
+
+    if (timeframe && Number.isFinite(timeframeVariation) && !Object.prototype.hasOwnProperty.call(metrics, timeframe)) {
+        metrics[timeframe] = timeframeVariation;
+    }
+
+    if (Number.isFinite(var24h) && !Object.prototype.hasOwnProperty.call(metrics, "24h")) {
+        metrics["24h"] = var24h;
+    }
+
+    return metrics;
+}
+
+export default function varAlert({ var24h, timeframe, timeframeVariation, variationByTimeframe, timeframeOrder = [] }) {
+    const metrics = sanitizeMetrics({ variationByTimeframe, timeframe, timeframeVariation, var24h });
+    const orderedLabels = sortLabels(Object.keys(metrics), timeframeOrder);
+
+    const segments = [];
+    for (const label of orderedLabels) {
+        const formatted = formatPercent(metrics[label]);
+        if (formatted) {
+            segments.push(`${label} ${formatted}`);
+        }
+    }
+
+    if (segments.length === 0) {
+        return [];
+    }
+
+    return [createAlert(`📊 Variações: ${segments.join(" • ")}`, ALERT_LEVELS.LOW, ALERT_CATEGORIES.VOLATILITY)];
+}
+
+export const __private__ = {
+    HIGHER_TIMEFRAME_METRICS,
+    formatPercent,
+    sortLabels,
+    sanitizeMetrics
+};

--- a/src/alerts/variationMetrics.js
+++ b/src/alerts/variationMetrics.js
@@ -1,0 +1,65 @@
+export const HIGHER_TIMEFRAME_METRICS = Object.freeze(["24h", "7d", "30d"]);
+const KPI_KEY_BY_LABEL = Object.freeze({
+    "24h": "var24h",
+    "7d": "var7d",
+    "30d": "var30d"
+});
+
+function isFiniteNumber(value) {
+    return typeof value === "number" && Number.isFinite(value);
+}
+
+function addMetric(target, label, value) {
+    if (!label || Object.prototype.hasOwnProperty.call(target, label)) {
+        return;
+    }
+    if (!isFiniteNumber(value)) {
+        return;
+    }
+    target[label] = value;
+}
+
+function resolveAnchorSnapshot(snapshots) {
+    if (snapshots?.["4h"]) {
+        return snapshots["4h"];
+    }
+    if (snapshots?.["1h"]) {
+        return snapshots["1h"];
+    }
+    const firstEntry = Object.values(snapshots ?? {}).find(Boolean);
+    return firstEntry ?? null;
+}
+
+/**
+ * Consolidates price variation metrics extracted from timeframe snapshots.
+ * @param {Object} params - Parameters for metric extraction.
+ * @param {Record<string, { kpis?: Record<string, number> }>} params.snapshots - KPI snapshots keyed by timeframe.
+ * @returns {Record<string, number>} Map with variation values per timeframe or horizon.
+ */
+export function collectVariationMetrics({ snapshots = {} } = {}) {
+    const metrics = {};
+
+    for (const [timeframe, snapshot] of Object.entries(snapshots)) {
+        addMetric(metrics, timeframe, snapshot?.kpis?.var);
+    }
+
+    const anchorSnapshot = resolveAnchorSnapshot(snapshots);
+    const anchorKpis = anchorSnapshot?.kpis ?? null;
+    if (anchorKpis) {
+        for (const label of HIGHER_TIMEFRAME_METRICS) {
+            const kpiKey = KPI_KEY_BY_LABEL[label];
+            addMetric(metrics, label, anchorKpis?.[kpiKey]);
+        }
+    }
+
+    return metrics;
+}
+
+export const __private__ = {
+    HIGHER_TIMEFRAME_METRICS,
+    isFiniteNumber,
+    addMetric,
+    resolveAnchorSnapshot,
+    KPI_KEY_BY_LABEL
+};
+

--- a/src/assets.js
+++ b/src/assets.js
@@ -1,3 +1,7 @@
+// Each asset can optionally provide a `marketCapRank` field so downstream
+// modules (like the alert dispatcher) can prioritise higher-cap markets when
+// sorting notifications. When omitted the ordering gracefully falls back to an
+// alphabetical comparison by `key`.
 export const ASSETS = [
     { key: "BTC", binance: process.env.BINANCE_SYMBOL_BTC },
     { key: "ETH", binance: process.env.BINANCE_SYMBOL_ETH },

--- a/src/config.js
+++ b/src/config.js
@@ -260,6 +260,15 @@ const DEFAULT_PORTFOLIO_REPORTING_CONFIG = {
     appendToUploads: false,
 };
 
+const DEFAULT_PORTFOLIO_DISCORD_CONFIG = {
+    enabled: false,
+    mention: "",
+    webhookUrl: "",
+    channelId: "",
+    locale: "pt-PT",
+    includeReportLinks: true,
+};
+
 const DEFAULT_PORTFOLIO_STRATEGY_CONFIG = {
     name: "Base Rebalance",
     allocation: {},
@@ -275,6 +284,7 @@ const DEFAULT_PORTFOLIO_GROWTH_CONFIG = {
     rebalance: DEFAULT_PORTFOLIO_REBALANCE_CONFIG,
     risk: DEFAULT_PORTFOLIO_RISK_CONFIG,
     reporting: DEFAULT_PORTFOLIO_REPORTING_CONFIG,
+    discord: DEFAULT_PORTFOLIO_DISCORD_CONFIG,
     strategies: {
         default: DEFAULT_PORTFOLIO_STRATEGY_CONFIG,
     },
@@ -508,6 +518,10 @@ const buildPortfolioGrowthConfig = (baseConfig = {}) => {
             ...defaults.reporting,
             ...(isPlainObject(base.reporting) ? base.reporting : {}),
         },
+        discord: {
+            ...defaults.discord,
+            ...(isPlainObject(base.discord) ? base.discord : {}),
+        },
         strategies: {},
     };
 
@@ -581,6 +595,27 @@ const buildPortfolioGrowthConfig = (baseConfig = {}) => {
     config.reporting.appendToUploads = toBoolean(
         process.env.PORTFOLIO_APPEND_UPLOADS,
         config.reporting.appendToUploads,
+    );
+
+    config.discord.enabled = toBoolean(process.env.PORTFOLIO_DISCORD_ENABLED, config.discord.enabled);
+    if (typeof process.env.PORTFOLIO_DISCORD_WEBHOOK === "string") {
+        const rawWebhook = process.env.PORTFOLIO_DISCORD_WEBHOOK.trim();
+        config.discord.webhookUrl = rawWebhook !== "" ? rawWebhook : "";
+    }
+    if (typeof process.env.PORTFOLIO_DISCORD_CHANNEL === "string") {
+        const rawChannel = process.env.PORTFOLIO_DISCORD_CHANNEL.trim();
+        config.discord.channelId = rawChannel !== "" ? rawChannel : "";
+    }
+    if (typeof process.env.PORTFOLIO_DISCORD_MENTION === "string") {
+        config.discord.mention = process.env.PORTFOLIO_DISCORD_MENTION.trim();
+    }
+    if (typeof process.env.PORTFOLIO_DISCORD_LOCALE === "string") {
+        const locale = process.env.PORTFOLIO_DISCORD_LOCALE.trim();
+        config.discord.locale = locale !== "" ? locale : config.discord.locale;
+    }
+    config.discord.includeReportLinks = toBoolean(
+        process.env.PORTFOLIO_DISCORD_INCLUDE_REPORTS,
+        config.discord.includeReportLinks,
     );
 
     const defaultStrategies = isPlainObject(defaults.strategies) ? defaults.strategies : {};
@@ -881,6 +916,10 @@ function rebuildConfig({ reloadFromDisk = true, emitLog = false } = {}) {
     nextCFG.enableAlerts = toBoolean(process.env.ENABLE_ALERTS, nextCFG.enableAlerts ?? true);
     nextCFG.enableAnalysis = toBoolean(process.env.ENABLE_ANALYSIS, nextCFG.enableAnalysis ?? true);
     nextCFG.enableReports = toBoolean(process.env.ENABLE_REPORTS, nextCFG.enableReports ?? true);
+    nextCFG.enableBinanceCommand = toBoolean(
+        process.env.ENABLE_BINANCE_COMMAND,
+        nextCFG.enableBinanceCommand ?? true,
+    );
     nextCFG.debug = toBoolean(process.env.DEBUG, nextCFG.debug ?? false);
     nextCFG.accountEquity = toNumber(process.env.ACCOUNT_EQUITY, nextCFG.accountEquity ?? 0);
     nextCFG.riskPerTrade = toNumber(process.env.RISK_PER_TRADE, nextCFG.riskPerTrade ?? 0.01);

--- a/src/discordBot.js
+++ b/src/discordBot.js
@@ -10,7 +10,12 @@ import { ASSETS, TIMEFRAMES, BINANCE_INTERVALS } from './assets.js';
 import { fetchOHLCV } from './data/binance.js';
 import { renderChartPNG } from './chart.js';
 import { addAssetToWatch, removeAssetFromWatch, getWatchlist as loadWatchlist } from './watchlist.js';
-import { setSetting, getSetting } from './settings.js';
+import { setSetting } from './settings.js';
+import {
+    getMinimumProfitSettings,
+    setDefaultMinimumProfit,
+    setPersonalMinimumProfit,
+} from './minimumProfit.js';
 import { getAccountOverview } from './trading/binance.js';
 
 const startTime = Date.now();
@@ -40,56 +45,12 @@ const priceFormatter = new Intl.NumberFormat('pt-BR', { minimumFractionDigits: 2
 const MIN_PROFIT_PERCENT_MIN = 0;
 const MIN_PROFIT_PERCENT_MAX = 100;
 
-function isPlainObject(value) {
-    return value !== null && typeof value === 'object' && !Array.isArray(value);
-}
-
 function formatAmount(value, formatter = amountFormatter) {
     return Number.isFinite(value) ? formatter.format(value) : '0,00';
 }
 
-function readMinimumProfitSettings() {
-    const fallback = isPlainObject(CFG.minimumProfitThreshold) ? CFG.minimumProfitThreshold : { default: 0, users: {} };
-    const stored = getSetting('minimumProfitThreshold', fallback);
-    if (!isPlainObject(stored)) {
-        return {
-            default: Number.isFinite(fallback.default) ? fallback.default : 0,
-            users: { ...isPlainObject(fallback.users) ? fallback.users : {} },
-        };
-    }
-    const baseDefault = Number.isFinite(stored.default)
-        ? stored.default
-        : Number.isFinite(fallback.default)
-            ? fallback.default
-            : 0;
-    const baseUsers = isPlainObject(stored.users)
-        ? stored.users
-        : isPlainObject(fallback.users)
-            ? fallback.users
-            : {};
-    const users = {};
-    for (const [userId, value] of Object.entries(baseUsers)) {
-        if (Number.isFinite(value) && value >= 0 && value <= 1) {
-            users[userId] = value;
-        }
-    }
-    return {
-        default: baseDefault >= 0 && baseDefault <= 1 ? baseDefault : 0,
-        users,
-    };
-}
-
 function formatPercentDisplay(value) {
     return value % 1 === 0 ? value.toFixed(0) : value.toFixed(2);
-}
-
-function applyMinimumProfitUpdate(nextValue) {
-    if (isPlainObject(CFG.minimumProfitThreshold)) {
-        CFG.minimumProfitThreshold.default = nextValue.default;
-        CFG.minimumProfitThreshold.users = nextValue.users;
-    } else {
-        CFG.minimumProfitThreshold = nextValue;
-    }
 }
 
 function formatAccountAssets(assets = []) {
@@ -278,6 +239,15 @@ export async function handleInteraction(interaction) {
             await interaction.editReply('Erro ao executar análise. Tente novamente mais tarde.');
         }
     } else if (interaction.commandName === 'binance') {
+        if (!CFG.enableBinanceCommand) {
+            if (typeof interaction.reply === 'function') {
+                await interaction.reply({
+                    content: 'O comando Binance está desativado neste servidor.',
+                    ephemeral: true,
+                });
+            }
+            return;
+        }
         await interaction.deferReply({ ephemeral: true });
         const log = withContext(logger, { command: 'binance' });
         try {
@@ -312,6 +282,31 @@ export async function handleInteraction(interaction) {
                 await interaction.reply({ content: 'Não foi possível atualizar o risco no momento.', ephemeral: true });
             }
         } else if (group === 'profit') {
+            if (sub === 'view') {
+                const settings = getMinimumProfitSettings();
+                const userId = interaction.user?.id ?? null;
+                const personalRatio = userId && settings.users[userId] !== undefined
+                    ? settings.users[userId]
+                    : null;
+                const appliedRatio = personalRatio !== null ? personalRatio : settings.default;
+                const defaultPercent = formatPercentDisplay(settings.default * 100);
+                const appliedPercent = formatPercentDisplay(appliedRatio * 100);
+                let personalLine;
+                if (personalRatio === null) {
+                    personalLine = 'Seu lucro mínimo: usando o padrão do servidor';
+                } else {
+                    const personalPercent = formatPercentDisplay(personalRatio * 100);
+                    personalLine = `Seu lucro mínimo: ${personalPercent}%`;
+                }
+                const lines = [
+                    `Lucro mínimo padrão: ${defaultPercent}%`,
+                    personalLine,
+                    `Valor aplicado nas análises: ${appliedPercent}%`,
+                ];
+                await interaction.reply({ content: lines.join('\n'), ephemeral: true });
+                return;
+            }
+
             if (sub !== 'default' && sub !== 'personal') {
                 await interaction.reply({ content: 'Configuração não suportada.', ephemeral: true });
                 return;
@@ -327,15 +322,9 @@ export async function handleInteraction(interaction) {
             const decimal = percent / 100;
             const formatted = formatPercentDisplay(percent);
             const log = withContext(logger, { command: 'settings', group, sub });
-            const current = readMinimumProfitSettings();
             try {
                 if (sub === 'default') {
-                    const nextValue = {
-                        default: decimal,
-                        users: { ...current.users },
-                    };
-                    setSetting('minimumProfitThreshold', nextValue);
-                    applyMinimumProfitUpdate(nextValue);
+                    setDefaultMinimumProfit(decimal);
                     await interaction.reply({
                         content: `Lucro mínimo padrão atualizado para ${formatted}%`,
                         ephemeral: true,
@@ -346,12 +335,7 @@ export async function handleInteraction(interaction) {
                         await interaction.reply({ content: 'Não foi possível identificar o usuário.', ephemeral: true });
                         return;
                     }
-                    const nextValue = {
-                        default: current.default,
-                        users: { ...current.users, [userId]: decimal },
-                    };
-                    setSetting('minimumProfitThreshold', nextValue);
-                    applyMinimumProfitUpdate(nextValue);
+                    setPersonalMinimumProfit(userId, decimal);
                     await interaction.reply({
                         content: `Lucro mínimo pessoal atualizado para ${formatted}%`,
                         ephemeral: true,
@@ -456,10 +440,6 @@ function getClient() {
                     ]
                 },
                 {
-                    name: 'binance',
-                    description: 'Mostra saldos, posições e margem da conta Binance'
-                },
-                {
                     name: 'settings',
                     description: 'Atualiza configurações do bot',
                     options: [
@@ -488,6 +468,11 @@ function getClient() {
                             description: 'Configurações de lucro mínimo',
                             type: ApplicationCommandOptionType.SubcommandGroup,
                             options: [
+                                {
+                                    name: 'view',
+                                    description: 'Mostra os valores configurados de lucro mínimo',
+                                    type: ApplicationCommandOptionType.Subcommand,
+                                },
                                 {
                                     name: 'default',
                                     description: 'Define o lucro mínimo padrão (0 a 100%)',
@@ -519,6 +504,12 @@ function getClient() {
                     ]
                 }
             ];
+            if (CFG.enableBinanceCommand) {
+                commands.splice(4, 0, {
+                    name: 'binance',
+                    description: 'Mostra saldos, posições e margem da conta Binance'
+                });
+            }
             await client.application.commands.set(commands);
             client.on('interactionCreate', handleInteraction);
             return client;

--- a/src/minimumProfit.js
+++ b/src/minimumProfit.js
@@ -1,0 +1,149 @@
+import { CFG } from "./config.js";
+import { getSetting, setSetting } from "./settings.js";
+
+const STORAGE_KEY = "minimumProfitThreshold";
+const DEFAULT_SETTINGS = { default: 0, users: {} };
+
+function isPlainObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function toRatio(value) {
+    if (value === undefined || value === null) {
+        return null;
+    }
+    const parsed = Number.parseFloat(value);
+    if (!Number.isFinite(parsed)) {
+        return null;
+    }
+    if (parsed < 0 || parsed > 1) {
+        return null;
+    }
+    return parsed;
+}
+
+function normalizeSettings(raw, fallback = DEFAULT_SETTINGS) {
+    const normalized = {
+        default: DEFAULT_SETTINGS.default,
+        users: {},
+    };
+
+    const fallbackDefault = toRatio(fallback?.default);
+    if (fallbackDefault !== null) {
+        normalized.default = fallbackDefault;
+    }
+
+    const parsedDefault = toRatio(raw?.default);
+    if (parsedDefault !== null) {
+        normalized.default = parsedDefault;
+    }
+
+    const fallbackUsers = isPlainObject(fallback?.users) ? fallback.users : DEFAULT_SETTINGS.users;
+    for (const [userId, value] of Object.entries(fallbackUsers)) {
+        const parsed = toRatio(value);
+        if (parsed !== null) {
+            normalized.users[userId] = parsed;
+        }
+    }
+
+    if (isPlainObject(raw?.users)) {
+        for (const [userId, value] of Object.entries(raw.users)) {
+            const parsed = toRatio(value);
+            if (parsed !== null) {
+                normalized.users[userId] = parsed;
+            } else if (userId in normalized.users) {
+                delete normalized.users[userId];
+            }
+        }
+    }
+
+    return normalized;
+}
+
+function cloneSettings(settings) {
+    return {
+        default: settings.default,
+        users: { ...settings.users },
+    };
+}
+
+function applyToConfig(settings) {
+    const normalized = normalizeSettings(settings, CFG.minimumProfitThreshold ?? DEFAULT_SETTINGS);
+    CFG.minimumProfitThreshold = cloneSettings(normalized);
+    return CFG.minimumProfitThreshold;
+}
+
+export function getMinimumProfitSettings() {
+    const fallback = isPlainObject(CFG.minimumProfitThreshold) ? CFG.minimumProfitThreshold : DEFAULT_SETTINGS;
+    const stored = getSetting(STORAGE_KEY, fallback);
+    const normalized = normalizeSettings(stored, fallback);
+    applyToConfig(normalized);
+    return cloneSettings(normalized);
+}
+
+function persistSettings(partialSettings) {
+    const current = getMinimumProfitSettings();
+    const merged = {
+        default: partialSettings.default ?? current.default,
+        users: {
+            ...current.users,
+            ...(isPlainObject(partialSettings.users) ? partialSettings.users : {}),
+        },
+    };
+    const normalized = normalizeSettings(merged, current);
+    setSetting(STORAGE_KEY, normalized);
+    applyToConfig(normalized);
+    return cloneSettings(normalized);
+}
+
+export function setDefaultMinimumProfit(ratio) {
+    const next = persistSettings({ default: ratio });
+    return next;
+}
+
+export function setPersonalMinimumProfit(userId, ratio) {
+    if (!userId) {
+        return getMinimumProfitSettings();
+    }
+    const next = persistSettings({ users: { [userId]: ratio } });
+    return next;
+}
+
+export function getMinimumProfitForUser(userId) {
+    const settings = getMinimumProfitSettings();
+    if (userId && settings.users[userId] !== undefined) {
+        return settings.users[userId];
+    }
+    return settings.default;
+}
+
+export function getDefaultMinimumProfitThreshold() {
+    return getMinimumProfitSettings().default;
+}
+
+export function computeTargetProfit(entry, target, { side = "long" } = {}) {
+    const entryValue = Number.parseFloat(entry);
+    const targetValue = Number.parseFloat(target);
+    if (!Number.isFinite(entryValue) || entryValue <= 0) {
+        return null;
+    }
+    if (!Number.isFinite(targetValue) || targetValue <= 0) {
+        return null;
+    }
+    const direction = side === "short" ? -1 : 1;
+    const diff = (targetValue - entryValue) * direction;
+    if (diff <= 0) {
+        return 0;
+    }
+    return diff / entryValue;
+}
+
+export function meetsMinimumProfitThreshold({ entry, target, side = "long", userId, threshold } = {}) {
+    const profitRatio = computeTargetProfit(entry, target, { side });
+    if (profitRatio === null) {
+        return false;
+    }
+    const baseThreshold = Number.isFinite(threshold) ? threshold : getMinimumProfitForUser(userId);
+    const normalizedThreshold = Number.isFinite(baseThreshold) && baseThreshold >= 0 ? baseThreshold : 0;
+    return profitRatio >= normalizedThreshold;
+}

--- a/src/portfolio/growthSummary.js
+++ b/src/portfolio/growthSummary.js
@@ -1,0 +1,190 @@
+import path from "node:path";
+
+const DEFAULT_LOCALE = "pt-PT";
+const CURRENCY = "EUR";
+
+const buildFormatter = (locale, options, fallback) => {
+    try {
+        return new Intl.NumberFormat(locale, options);
+    } catch (_) {
+        const fallbackLocale = typeof fallback === "string" && fallback.trim() !== "" ? fallback : "en-US";
+        return new Intl.NumberFormat(fallbackLocale, options);
+    }
+};
+
+const formatCurrency = (value, { locale = DEFAULT_LOCALE } = {}) => {
+    const formatter = buildFormatter(locale, {
+        style: "currency",
+        currency: CURRENCY,
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+    });
+    if (!Number.isFinite(value)) {
+        return formatter.format(0);
+    }
+    return formatter.format(value);
+};
+
+const formatPercent = (value, { locale = DEFAULT_LOCALE, minimumFractionDigits = 2, maximumFractionDigits = 2 } = {}) => {
+    const formatter = buildFormatter(locale, {
+        style: "percent",
+        minimumFractionDigits,
+        maximumFractionDigits,
+    });
+    if (!Number.isFinite(value)) {
+        return formatter.format(0);
+    }
+    return formatter.format(value);
+};
+
+const formatNumber = (value, { locale = DEFAULT_LOCALE, minimumFractionDigits = 0, maximumFractionDigits = 2 } = {}) => {
+    const formatter = buildFormatter(locale, {
+        minimumFractionDigits,
+        maximumFractionDigits,
+    });
+    if (!Number.isFinite(value)) {
+        return formatter.format(0);
+    }
+    return formatter.format(value);
+};
+
+const formatDate = (value, { locale = DEFAULT_LOCALE } = {}) => {
+    if (!value) {
+        return null;
+    }
+    const date = value instanceof Date ? value : new Date(value);
+    if (Number.isNaN(date.getTime())) {
+        return null;
+    }
+    try {
+        const formatter = new Intl.DateTimeFormat(locale, { dateStyle: "medium" });
+        return formatter.format(date);
+    } catch (_) {
+        const formatter = new Intl.DateTimeFormat("en-US", { dateStyle: "medium" });
+        return formatter.format(date);
+    }
+};
+
+const formatYears = (value, { locale = DEFAULT_LOCALE } = {}) => {
+    if (!Number.isFinite(value) || value <= 0) {
+        return null;
+    }
+    const formatter = buildFormatter(locale, { minimumFractionDigits: 1, maximumFractionDigits: 1 });
+    return `${formatter.format(value)} anos`;
+};
+
+const sanitizeMention = (mention) => {
+    if (typeof mention !== "string") {
+        return "";
+    }
+    const trimmed = mention.trim();
+    if (trimmed === "@here" || trimmed === "@everyone" || /^<@&\d+>$/.test(trimmed) || /^<@!\d+>$/.test(trimmed)) {
+        return trimmed;
+    }
+    return trimmed;
+};
+
+const formatReportsLine = ({ summary, includeReportLinks, locale }) => {
+    if (!includeReportLinks) {
+        return null;
+    }
+    const reportPaths = [];
+    const summaryPath = summary?.reports?.summaryPath;
+    const chartPath = summary?.reports?.chartPath;
+    if (typeof summaryPath === "string" && summaryPath.trim() !== "") {
+        reportPaths.push(path.relative(process.cwd(), summaryPath));
+    }
+    if (typeof chartPath === "string" && chartPath.trim() !== "") {
+        reportPaths.push(path.relative(process.cwd(), chartPath));
+    }
+    if (reportPaths.length === 0) {
+        return null;
+    }
+    const formatter = buildFormatter(locale, { style: "percent", minimumFractionDigits: 0, maximumFractionDigits: 0 });
+    const progressPct = Number.isFinite(summary?.progress?.pct)
+        ? formatPercent(summary.progress.pct, { locale, minimumFractionDigits: 2, maximumFractionDigits: 2 })
+        : formatter.format(0);
+    return `- Relatórios salvos (${progressPct} da meta): ${reportPaths.map(entry => `\`${entry}\``).join(", ")}`;
+};
+
+/**
+ * Builds a Discord-friendly summary message describing the current state of the 100€ → 10M€ simulation.
+ * @param {Object} params - Message builder parameters.
+ * @param {Object} params.summary - Result returned by the portfolio growth simulation.
+ * @param {string} [params.mention] - Optional mention ("@here", role id, etc.).
+ * @param {string} [params.locale] - Locale used to format numeric values.
+ * @param {boolean} [params.includeReportLinks=true] - When true, append local report paths to the message.
+ * @returns {string} Discord message body.
+ */
+export function buildPortfolioGrowthDiscordMessage({
+    summary,
+    mention = "",
+    locale = DEFAULT_LOCALE,
+    includeReportLinks = true,
+} = {}) {
+    if (!summary || typeof summary !== "object") {
+        return "";
+    }
+
+    const safeLocale = typeof locale === "string" && locale.trim() !== "" ? locale : DEFAULT_LOCALE;
+    const lines = [];
+    const sanitizedMention = sanitizeMention(mention);
+    if (sanitizedMention) {
+        lines.push(sanitizedMention);
+    }
+
+    const strategyName = typeof summary.strategy === "string" && summary.strategy.trim() !== ""
+        ? summary.strategy.trim()
+        : "Default";
+    lines.push(`**Simulação 100€ → 10M€ · ${strategyName}**`);
+
+    const finalValue = Number(summary.finalValue) || 0;
+    const totalReturnPct = Number(summary.metrics?.totalReturnPct) || 0;
+    const cagr = Number(summary.metrics?.cagr) || 0;
+    lines.push(`- Valor atual: ${formatCurrency(finalValue, { locale: safeLocale })} (${formatPercent(totalReturnPct, { locale: safeLocale })} total | CAGR ${formatPercent(cagr, { locale: safeLocale })})`);
+
+    const investedCapital = Number(summary.investedCapital) || 0;
+    const contributionsTotal = Number(summary.contributionsTotal) || 0;
+    const contributionsCount = Number.isFinite(summary.contributionsCount) ? summary.contributionsCount : 0;
+    lines.push(`- Capital investido: ${formatCurrency(investedCapital, { locale: safeLocale })} (aportes ${formatCurrency(contributionsTotal, { locale: safeLocale })} em ${formatNumber(contributionsCount, { locale: safeLocale, minimumFractionDigits: 0, maximumFractionDigits: 0 })} contribuições)`);
+
+    const targetCapital = Number(summary.targetCapital) || 0;
+    const progressPct = Number(summary.progress?.pct) || 0;
+    if (summary.targetReached && summary.targetReachedAt) {
+        const reachedDate = formatDate(summary.targetReachedAt, { locale: safeLocale });
+        lines.push(`- Meta atingida: ${formatCurrency(targetCapital, { locale: safeLocale })} em ${reachedDate ?? summary.targetReachedAt}`);
+    } else {
+        const remaining = Math.max(0, targetCapital - finalValue);
+        const remainingStr = formatCurrency(remaining, { locale: safeLocale });
+        const progressStr = formatPercent(progressPct, { locale: safeLocale });
+        const estimatedYears = formatYears(summary.progress?.estimatedYearsToTarget, { locale: safeLocale });
+        const estimateSuffix = estimatedYears ? ` · projeção ${estimatedYears}` : "";
+        lines.push(`- Meta: ${formatCurrency(targetCapital, { locale: safeLocale })} · progresso ${progressStr} · falta ${remainingStr}${estimateSuffix}`);
+    }
+
+    const maxDrawdown = Number(summary.metrics?.maxDrawdownPct) || 0;
+    const volatility = Number(summary.metrics?.annualizedVolatility) || 0;
+    const sharpeRatio = Number(summary.metrics?.sharpeRatio) || 0;
+    lines.push(`- Risco: drawdown máx ${formatPercent(maxDrawdown, { locale: safeLocale })} · vol anual ${formatPercent(volatility, { locale: safeLocale })} · Sharpe ${formatNumber(sharpeRatio, { locale: safeLocale, minimumFractionDigits: 2, maximumFractionDigits: 2 })}`);
+
+    const durationDays = Number(summary.metrics?.durationDays) || 0;
+    const yearsElapsed = durationDays > 0 ? durationDays / 365 : 0;
+    if (yearsElapsed > 0) {
+        lines.push(`- Janela analisada: ${formatNumber(yearsElapsed, { locale: safeLocale, minimumFractionDigits: 1, maximumFractionDigits: 1 })} anos (${formatNumber(durationDays, { locale: safeLocale, minimumFractionDigits: 0, maximumFractionDigits: 0 })} dias)`);
+    }
+
+    const reportsLine = formatReportsLine({ summary, includeReportLinks, locale: safeLocale });
+    if (reportsLine) {
+        lines.push(reportsLine);
+    }
+
+    return lines.join("\n");
+}
+
+export const __testUtils = {
+    formatCurrency,
+    formatPercent,
+    formatNumber,
+    formatDate,
+    formatYears,
+};

--- a/src/trading/automation.js
+++ b/src/trading/automation.js
@@ -1,0 +1,221 @@
+import { CFG } from "../config.js";
+import { logger, withContext } from "../logger.js";
+import { getMarginPositionRisk } from "./binance.js";
+import { openPosition, closePosition } from "./executor.js";
+
+function isPlainObject(value) {
+    return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function toFinite(value) {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+function getTradingConfig() {
+    return isPlainObject(CFG.trading) ? CFG.trading : {};
+}
+
+function getAutomationConfig() {
+    const tradingCfg = getTradingConfig();
+    const base = isPlainObject(tradingCfg.automation) ? tradingCfg.automation : {};
+    return {
+        enabled: Boolean(base.enabled),
+        timeframe: typeof base.timeframe === "string" && base.timeframe.length > 0 ? base.timeframe : "4h",
+        minConfidence: toFinite(base.minConfidence) ?? 0.55,
+        positionPct: toFinite(base.positionPct) ?? 0.05,
+        maxPositions: Number.isInteger(base.maxPositions) && base.maxPositions > 0 ? base.maxPositions : 3,
+        positionEpsilon: toFinite(base.positionEpsilon) ?? 0.0001,
+        mode: typeof base.mode === "string" ? base.mode : "margin",
+    };
+}
+
+function mapDecisionToDirection(decision) {
+    if (!decision) {
+        return "flat";
+    }
+    const normalized = decision.toLowerCase();
+    if (normalized === "buy") {
+        return "long";
+    }
+    if (normalized === "sell") {
+        return "short";
+    }
+    return "flat";
+}
+
+function extractConfidence({ strategy, posture, decision }) {
+    const candidates = [strategy?.confidence, decision?.confidence, posture?.confidence];
+    for (const value of candidates) {
+        const parsed = toFinite(value);
+        if (parsed !== null) {
+            return parsed;
+        }
+    }
+    return null;
+}
+
+function filterActivePositions(positions, epsilon) {
+    if (!Array.isArray(positions)) {
+        return [];
+    }
+    return positions.filter(position => {
+        const qty = toFinite(position?.positionAmt);
+        return qty !== null && Math.abs(qty) > epsilon;
+    });
+}
+
+function normalizeSymbol(symbol) {
+    return typeof symbol === "string" ? symbol.toUpperCase() : null;
+}
+
+function findPositionForSymbol(positions, symbol, epsilon) {
+    const normalized = normalizeSymbol(symbol);
+    if (!normalized) {
+        return null;
+    }
+    return positions.find(position => normalizeSymbol(position?.symbol) === normalized && Math.abs(toFinite(position?.positionAmt) ?? 0) > epsilon) ?? null;
+}
+
+function computeQuantity({ price, positionPct }) {
+    const equity = toFinite(CFG.accountEquity);
+    const pct = toFinite(positionPct);
+    if (equity === null || equity <= 0 || pct === null || pct <= 0) {
+        return null;
+    }
+    const referencePrice = toFinite(price);
+    if (referencePrice === null || referencePrice <= 0) {
+        return null;
+    }
+    const notional = equity * pct;
+    const quantity = notional / referencePrice;
+    return quantity > 0 ? quantity : null;
+}
+
+function derivePositionDirection(positionAmt, epsilon) {
+    const qty = toFinite(positionAmt);
+    if (qty === null || Math.abs(qty) <= epsilon) {
+        return "flat";
+    }
+    return qty > 0 ? "long" : "short";
+}
+
+export async function automateTrading({
+    assetKey,
+    symbol,
+    timeframe,
+    decision,
+    posture,
+    strategy,
+    snapshot,
+} = {}) {
+    const tradingCfg = getTradingConfig();
+    const automationCfg = getAutomationConfig();
+    const log = withContext(logger, { asset: assetKey ?? symbol, action: "automateTrading" });
+
+    if (!tradingCfg.enabled || !automationCfg.enabled) {
+        return { skipped: true, reason: "disabled" };
+    }
+
+    if (typeof symbol !== "string" || symbol.length === 0) {
+        return { skipped: true, reason: "missingSymbol" };
+    }
+
+    if (timeframe !== automationCfg.timeframe) {
+        return { skipped: true, reason: "timeframeMismatch" };
+    }
+
+    const direction = mapDecisionToDirection(decision?.decision ?? decision);
+    const confidence = extractConfidence({ strategy, posture, decision });
+
+    if (direction !== "flat" && confidence !== null && confidence < automationCfg.minConfidence) {
+        log.debug({ fn: "automateTrading", confidence }, 'Skipped trade due to low confidence');
+        return { skipped: true, reason: "lowConfidence", confidence };
+    }
+
+    if (direction === "flat") {
+        const positions = filterActivePositions(await getMarginPositionRisk({ symbol }), automationCfg.positionEpsilon);
+        const existing = findPositionForSymbol(positions, symbol, automationCfg.positionEpsilon);
+        if (!existing) {
+            return { skipped: true, reason: "noPosition" };
+        }
+        const existingDirection = derivePositionDirection(existing.positionAmt, automationCfg.positionEpsilon);
+        try {
+            await closePosition({
+                symbol,
+                assetKey,
+                direction: existingDirection,
+                quantity: Math.abs(existing.positionAmt),
+                metadata: { referencePrice: snapshot?.kpis?.price },
+            });
+            log.info({ fn: "automateTrading", direction: existingDirection }, 'Closed position after flat signal');
+            return { executed: true, action: "close", direction: existingDirection };
+        } catch (err) {
+            log.error({ fn: "automateTrading", err }, 'Failed to close position');
+            throw err;
+        }
+    }
+
+    const positions = filterActivePositions(await getMarginPositionRisk(), automationCfg.positionEpsilon);
+    const existing = findPositionForSymbol(positions, symbol, automationCfg.positionEpsilon);
+    const existingDirection = derivePositionDirection(existing?.positionAmt, automationCfg.positionEpsilon);
+
+    if (!existing && positions.length >= automationCfg.maxPositions) {
+        log.warn({ fn: "automateTrading", positions: positions.length }, 'Skipped trade due to max positions');
+        return { skipped: true, reason: "maxPositions" };
+    }
+
+    const price = snapshot?.kpis?.price;
+    const quantity = computeQuantity({ price, positionPct: automationCfg.positionPct });
+    if (quantity === null) {
+        log.warn({ fn: "automateTrading", price }, 'Skipped trade due to invalid sizing');
+        return { skipped: true, reason: "invalidSizing" };
+    }
+
+    if (existingDirection === direction) {
+        log.debug({ fn: "automateTrading", direction }, 'Position already aligned with signal');
+        return { skipped: true, reason: "alreadyAligned" };
+    }
+
+    if (existingDirection !== "flat" && existingDirection !== direction) {
+        try {
+            await closePosition({
+                symbol,
+                assetKey,
+                direction: existingDirection,
+                quantity: Math.abs(existing.positionAmt),
+                metadata: { referencePrice: price },
+            });
+            log.info({ fn: "automateTrading", from: existingDirection, to: direction }, 'Closed opposing position before reversal');
+        } catch (err) {
+            log.error({ fn: "automateTrading", err }, 'Failed to close opposing position');
+            throw err;
+        }
+    }
+
+    try {
+        await openPosition({
+            symbol,
+            assetKey,
+            direction,
+            quantity,
+            metadata: { referencePrice: price },
+        });
+        log.info({ fn: "automateTrading", direction, quantity }, 'Opened automated position');
+        return { executed: true, action: "open", direction, quantity };
+    } catch (err) {
+        log.error({ fn: "automateTrading", err }, 'Failed to open position');
+        throw err;
+    }
+}
+
+export const __private__ = {
+    getTradingConfig,
+    getAutomationConfig,
+    mapDecisionToDirection,
+    extractConfidence,
+    filterActivePositions,
+    findPositionForSymbol,
+    computeQuantity,
+    derivePositionDirection,
+};

--- a/tests/alerts-config.test.js
+++ b/tests/alerts-config.test.js
@@ -36,6 +36,8 @@ const createBaseData = () => ({
   cciSeries: Array(21).fill(0),
   obvSeries: Array(21).fill(1000),
   var24h: 0,
+  variationByTimeframe: { '4h': 0, '24h': 0 },
+  timeframeOrder: ['4h', '1h', '30m', '15m', '5m'],
   equity: 1000,
   riskPct: 0.01
 });

--- a/tests/alerts.test.js
+++ b/tests/alerts.test.js
@@ -14,6 +14,8 @@ describe('buildAlerts', () => {
       timeframe: '4h',
       timeframeVariation: 0.02,
       var24h: 0.045,
+      variationByTimeframe: { '4h': 0.02, '1h': 0.015, '24h': 0.045 },
+      timeframeOrder: ['4h', '1h', '30m', '15m', '5m'],
       closes: Array(20).fill(90).concat(100),
       highs: Array(21).fill(100),
       lows: Array(21).fill(80),
@@ -30,8 +32,7 @@ describe('buildAlerts', () => {
       expect.objectContaining({ msg: '📈 KC breakout above', level: ALERT_LEVELS.HIGH }),
       expect.objectContaining({ msg: '💪 ADX>25 (tendência forte)', level: ALERT_LEVELS.HIGH }),
       expect.objectContaining({ msg: '💰 Preço: 100.0000', level: ALERT_LEVELS.LOW }),
-      expect.objectContaining({ msg: '📊 Var4h: +2.00%', level: ALERT_LEVELS.LOW }),
-      expect.objectContaining({ msg: '📊 Var24h: +4.50%', level: ALERT_LEVELS.LOW })
+      expect.objectContaining({ msg: '📊 Variações: 4h +2.00% • 1h +1.50% • 24h +4.50%', level: ALERT_LEVELS.LOW })
     ]));
 
     const levels = alerts.map(alert => alert.level);
@@ -53,6 +54,8 @@ describe('buildAlerts', () => {
       timeframe: '4h',
       timeframeVariation: -0.05,
       var24h: -0.08,
+      variationByTimeframe: { '4h': -0.05, '24h': -0.08 },
+      timeframeOrder: ['4h', '1h', '30m', '15m', '5m'],
       closes,
       highs: Array(21).fill(85),
       lows: Array(21).fill(65),
@@ -79,6 +82,8 @@ describe('buildAlerts', () => {
       timeframe: '4h',
       timeframeVariation: 0,
       var24h: 0,
+      variationByTimeframe: { '4h': 0, '24h': 0 },
+      timeframeOrder: ['4h', '1h', '30m', '15m', '5m'],
       closes: Array(20).fill(lastClose).concat(lastClose),
       highs: Array(21).fill(lastClose + 1),
       lows: Array(21).fill(lastClose - 1),
@@ -105,6 +110,8 @@ describe('buildAlerts', () => {
       timeframe: '4h',
       timeframeVariation: 0,
       var24h: 0,
+      variationByTimeframe: { '4h': 0, '24h': 0 },
+      timeframeOrder: ['4h', '1h', '30m', '15m', '5m'],
       closes: Array(20).fill(lastClose).concat(lastClose),
       highs: Array(21).fill(lastClose + 10),
       lows: Array(21).fill(lastClose - 10),

--- a/tests/alerts/decision.test.js
+++ b/tests/alerts/decision.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { deriveDecisionDetails, formatDecisionLine, DECISION_LABELS } from '../../src/alerts/decision.js';
+
+describe('deriveDecisionDetails', () => {
+  it('derives buy decision from long strategy with posture context', () => {
+    const details = deriveDecisionDetails({
+      strategy: {
+        action: 'long',
+        posture: 'bullish',
+        confidence: 0.58,
+        reasons: ['fast MA above slow MA threshold', 'trend strength confirmed']
+      },
+      posture: {
+        posture: 'bullish',
+        confidence: 0.6,
+        reasons: ['fallback reason should be ignored']
+      }
+    });
+
+    expect(details.decision).toBe(DECISION_LABELS.BUY);
+    expect(details.emoji).toBe('🟢');
+    expect(details.posture).toBe('bullish');
+    expect(details.confidence).toBe(0.58);
+    expect(details.reasons).toEqual(['fast MA above slow MA threshold', 'trend strength confirmed']);
+  });
+
+  it('falls back to hold when strategy action missing', () => {
+    const details = deriveDecisionDetails({
+      strategy: {
+        action: null,
+        confidence: 'not-a-number'
+      },
+      posture: {
+        posture: 'neutral',
+        reasons: ['neutral trend'],
+        confidence: 0.25
+      }
+    });
+
+    expect(details.decision).toBe(DECISION_LABELS.HOLD);
+    expect(details.emoji).toBe('🟡');
+    expect(details.posture).toBe('neutral');
+    expect(details.confidence).toBe(0.25);
+    expect(details.reasons).toEqual(['neutral trend']);
+  });
+});
+
+describe('formatDecisionLine', () => {
+  it('formats decision details into a readable summary', () => {
+    const summary = formatDecisionLine({
+      decision: DECISION_LABELS.BUY,
+      emoji: '🟢',
+      posture: 'bullish',
+      confidence: 0.61,
+      reasons: ['fast MA above slow MA threshold']
+    });
+
+    expect(summary).toBe('🟢 BUY — postura tendência de alta — confiança 61% — motivos: fast MA above slow MA threshold');
+  });
+
+  it('returns null when details are missing', () => {
+    expect(formatDecisionLine(null)).toBeNull();
+    expect(formatDecisionLine({})).toBeNull();
+  });
+});

--- a/tests/alerts/dispatcher.test.js
+++ b/tests/alerts/dispatcher.test.js
@@ -1,31 +1,70 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { enqueueAlertPayload, flushAlertQueue, clearAlertQueue } from '../../src/alerts/dispatcher.js';
+
+async function importDispatcher({ assets } = {}) {
+  vi.resetModules();
+  if (assets) {
+    vi.doMock('../../src/assets.js', () => ({ ASSETS: assets }));
+  } else {
+    vi.unmock('../../src/assets.js');
+  }
+  const module = await import('../../src/alerts/dispatcher.js');
+  return module;
+}
 
 describe('alert dispatcher', () => {
   afterEach(() => {
-    clearAlertQueue();
+    vi.resetModules();
+    vi.unmock('../../src/assets.js');
   });
 
-  it('sorts queued payloads by asset and timeframe order', async () => {
+  it('sorts queued payloads alphabetically when no market cap data is provided', async () => {
+    const { enqueueAlertPayload, flushAlertQueue, clearAlertQueue } = await importDispatcher();
     const sender = vi.fn(() => Promise.resolve());
 
-    enqueueAlertPayload({ asset: 'ETH', timeframe: '1h', message: 'ETH 1h' });
+    enqueueAlertPayload({ asset: 'SOL', timeframe: '1h', message: 'SOL 1h' });
+    enqueueAlertPayload({ asset: 'ETH', timeframe: '4h', message: 'ETH 4h' });
     enqueueAlertPayload({ asset: 'BTC', timeframe: '1h', message: 'BTC 1h' });
-    enqueueAlertPayload({ asset: 'BTC', timeframe: '4h', message: 'BTC 4h' });
 
     await flushAlertQueue({ sender, timeframeOrder: ['4h', '1h'] });
 
     expect(sender).toHaveBeenCalledTimes(3);
     const order = sender.mock.calls.map(call => call[0].message);
-    expect(order).toEqual(['BTC 4h', 'BTC 1h', 'ETH 1h']);
+    expect(order).toEqual(['BTC 1h', 'ETH 4h', 'SOL 1h']);
+
+    clearAlertQueue();
+  });
+
+  it('prioritises assets with market cap rank metadata before alphabetical fallback', async () => {
+    const marketCapAssets = [
+      { key: 'SOL', marketCapRank: 10 },
+      { key: 'BTC', marketCapRank: 1 },
+      { key: 'ETH', marketCapRank: 2 },
+    ];
+    const { enqueueAlertPayload, flushAlertQueue, clearAlertQueue } = await importDispatcher({ assets: marketCapAssets });
+    const sender = vi.fn(() => Promise.resolve());
+
+    enqueueAlertPayload({ asset: 'SOL', timeframe: '1h', message: 'SOL 1h' });
+    enqueueAlertPayload({ asset: 'BTC', timeframe: '4h', message: 'BTC 4h' });
+    enqueueAlertPayload({ asset: 'ETH', timeframe: '1h', message: 'ETH 1h' });
+
+    await flushAlertQueue({ sender, timeframeOrder: ['4h', '1h'] });
+
+    expect(sender).toHaveBeenCalledTimes(3);
+    const order = sender.mock.calls.map(call => call[0].message);
+    expect(order).toEqual(['BTC 4h', 'ETH 1h', 'SOL 1h']);
+
+    clearAlertQueue();
   });
 
   it('clears queue even when no sender provided', async () => {
+    const { enqueueAlertPayload, flushAlertQueue, clearAlertQueue } = await importDispatcher();
     enqueueAlertPayload({ asset: 'BTC', timeframe: '4h', message: 'BTC alert' });
     await flushAlertQueue();
 
     const sender = vi.fn(() => Promise.resolve());
     await flushAlertQueue({ sender });
     expect(sender).not.toHaveBeenCalled();
+
+    clearAlertQueue();
   });
 });

--- a/tests/alerts/messageBuilder.test.js
+++ b/tests/alerts/messageBuilder.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildAssetAlertMessage } from '../../src/alerts/messageBuilder.js';
+import { buildAssetAlertMessage, __private__ } from '../../src/alerts/messageBuilder.js';
 import { ALERT_LEVELS, ALERT_CATEGORIES } from '../../src/alerts/shared.js';
 
 describe('buildAssetAlertMessage', () => {
@@ -11,6 +11,25 @@ describe('buildAssetAlertMessage', () => {
         {
           timeframe: '4h',
           guidance: 'Comprar (📈)',
+          decision: {
+            decision: 'buy',
+            emoji: '🟢',
+            posture: 'bullish',
+            confidence: 0.62,
+            reasons: ['fast MA above slow MA threshold']
+          },
+          forecast: {
+            forecastClose: 106,
+            lastClose: 105,
+            delta: 1,
+            confidence: 0.72,
+            predictedAt: '2024-01-01T12:00:00Z',
+            timeZone: 'UTC',
+            evaluation: {
+              pctError: 0.02,
+              directionHit: true
+            }
+          },
           alerts: [
             { msg: '📈 Breakout', level: ALERT_LEVELS.HIGH, category: ALERT_CATEGORIES.TREND, count: 2 }
           ]
@@ -18,20 +37,38 @@ describe('buildAssetAlertMessage', () => {
         {
           timeframe: '1h',
           guidance: 'Manter (🔁)',
+          decision: {
+            decision: 'hold',
+            emoji: '🟡',
+            posture: 'neutral',
+            confidence: null,
+            reasons: []
+          },
+          forecast: {
+            forecastClose: 99,
+            lastClose: 100,
+            confidence: 0.35,
+            predictedAt: '2024-01-01T13:00:00Z',
+            timeZone: 'UTC'
+          },
           alerts: [
             { msg: '⚠️ Pullback detectado', level: ALERT_LEVELS.MEDIUM, category: ALERT_CATEGORIES.INFO }
           ]
         }
       ],
-      variationByTimeframe: { '4h': 0.0123, '1h': -0.01 },
+      variationByTimeframe: { '4h': 0.0123, '1h': -0.01, '24h': 0.05 },
       timeframeOrder: ['4h', '1h']
     });
 
     expect(message).toContain('**⚠️ Alertas — BTC** @here');
-    expect(message).toContain('_Variações: 4h +1.23% • 1h -1.00%_');
+    expect(message).toContain('_Variações: 4h +1.23% • 1h -1.00% • 24h +5.00%_');
     expect(message).toContain('> **4h** — Recomendação: Comprar (📈) — Variação: +1.23%');
     expect(message).toContain('> **1h** — Recomendação: Manter (🔁) — Variação: -1.00%');
+    expect(message).toContain('↳ Previsão: 🔮 106.00 — Δ +1.00 (0.95%) — confiança 72% — alvo 01/01, 12:00 — histórico erro 2.00% | direção ✅');
+    expect(message).toContain('↳ Previsão: 🔮 99.00 — Δ -1.00 (-1.00%) — confiança 35% — alvo 01/01, 13:00');
     expect(message).toContain('• 🔴 **ALTA:** _Tendência_ — 📈 Breakout x2');
+    expect(message).toContain('↳ Decisão: 🟢 BUY — postura tendência de alta — confiança 62% — motivos: fast MA above slow MA threshold');
+    expect(message).toContain('↳ Decisão: 🟡 HOLD — postura neutra');
   });
 
   it('returns null when summaries have no alerts', () => {
@@ -43,5 +80,29 @@ describe('buildAssetAlertMessage', () => {
     });
 
     expect(message).toBeNull();
+  });
+});
+
+describe('formatForecastLine', () => {
+  const { formatForecastLine } = __private__;
+
+  it('formats forecast details with fallback delta and evaluation', () => {
+    const line = formatForecastLine({
+      forecastClose: 20500.123,
+      lastClose: 20000,
+      confidence: 0.66,
+      predictedAt: '2024-02-02T15:30:00Z',
+      timeZone: 'Europe/Lisbon',
+      evaluation: {
+        pctError: 0.031,
+        directionHit: false
+      }
+    });
+
+    expect(line).toContain('🔮 20500.12');
+    expect(line).toContain('Δ +500.12 (2.50%)');
+    expect(line).toContain('confiança 66%');
+    expect(line).toMatch(/alvo \d{2}\/\d{2}, \d{2}:\d{2}/);
+    expect(line).toContain('histórico erro 3.10% | direção ❌');
   });
 });

--- a/tests/alerts/tradeLevelsAlert.test.js
+++ b/tests/alerts/tradeLevelsAlert.test.js
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const settingsStore = {};
+
+const getSettingMock = vi.fn((key, fallback) => (key in settingsStore ? settingsStore[key] : fallback));
+const setSettingMock = vi.fn((key, value) => {
+    settingsStore[key] = value;
+    return value;
+});
+const loadSettingsMock = vi.fn(() => settingsStore);
+
+vi.mock('../../src/settings.js', () => ({
+    getSetting: getSettingMock,
+    setSetting: setSettingMock,
+    loadSettings: loadSettingsMock,
+}));
+
+function resetSettingsStore() {
+    for (const key of Object.keys(settingsStore)) {
+        delete settingsStore[key];
+    }
+}
+
+describe('tradeLevelsAlert minimum profit integration', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        resetSettingsStore();
+        getSettingMock.mockClear();
+        setSettingMock.mockClear();
+        loadSettingsMock.mockClear();
+    });
+
+    it('includes profit details when the ATR target meets the minimum threshold', async () => {
+        settingsStore.minimumProfitThreshold = { default: 0.02, users: {} };
+        const module = await import('../../src/alerts/tradeLevelsAlert.js');
+        const tradeLevelsAlert = module.default;
+
+        const alerts = tradeLevelsAlert({
+            lastClose: 100,
+            atrSeries: [1],
+            equity: 10000,
+            riskPct: 0.01,
+        });
+
+        expect(alerts).toHaveLength(1);
+        expect(alerts[0].msg.startsWith('🎯')).toBe(true);
+        expect(alerts[0].msg).toContain('Lucro potencial 2% (mínimo 2%)');
+    });
+
+    it('warns when the projected profit is below the configured threshold', async () => {
+        settingsStore.minimumProfitThreshold = { default: 0.05, users: {} };
+        const module = await import('../../src/alerts/tradeLevelsAlert.js');
+        const tradeLevelsAlert = module.default;
+
+        const alerts = tradeLevelsAlert({
+            lastClose: 100,
+            atrSeries: [1],
+            equity: 10000,
+            riskPct: 0.01,
+        });
+
+        expect(alerts).toHaveLength(1);
+        expect(alerts[0].msg.startsWith('⚠️')).toBe(true);
+        expect(alerts[0].msg).toContain('Lucro potencial 2% abaixo do mínimo 5%');
+    });
+});

--- a/tests/alerts/varAlert.test.js
+++ b/tests/alerts/varAlert.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import varAlert, { __private__ } from '../../src/alerts/varAlert.js';
+import { ALERT_LEVELS, ALERT_CATEGORIES } from '../../src/alerts/shared.js';
+
+describe('varAlert', () => {
+  it('aggregates multi-timeframe variation metrics with ordering', () => {
+    const alerts = varAlert({
+      timeframe: '1h',
+      timeframeVariation: -0.0123,
+      var24h: 0.0456,
+      variationByTimeframe: { '4h': 0.02, '1h': -0.0123, '24h': 0.0456, '7d': 0.12 },
+      timeframeOrder: ['4h', '1h', '30m', '15m', '5m']
+    });
+
+    expect(alerts).toEqual([
+      {
+        msg: '📊 Variações: 4h +2.00% • 1h -1.23% • 24h +4.56% • 7d +12.00%',
+        level: ALERT_LEVELS.LOW,
+        category: ALERT_CATEGORIES.VOLATILITY
+      }
+    ]);
+  });
+
+  it('falls back to timeframe and daily values when variation map is empty', () => {
+    const alerts = varAlert({
+      timeframe: '4h',
+      timeframeVariation: 0.031,
+      var24h: -0.015,
+      variationByTimeframe: {},
+      timeframeOrder: ['4h', '1h']
+    });
+
+    expect(alerts).toEqual([
+      {
+        msg: '📊 Variações: 4h +3.10% • 24h -1.50%',
+        level: ALERT_LEVELS.LOW,
+        category: ALERT_CATEGORIES.VOLATILITY
+      }
+    ]);
+  });
+
+  it('returns an empty array when no metrics are available', () => {
+    const alerts = varAlert({
+      timeframe: '1h',
+      variationByTimeframe: null
+    });
+
+    expect(alerts).toEqual([]);
+  });
+});
+
+describe('varAlert internals', () => {
+  it('sorts labels respecting timeframe priority and fallback order', () => {
+    const labels = __private__.sortLabels(['7d', '24h', '30m', '1h'], ['4h', '1h', '30m']);
+    expect(labels).toEqual(['1h', '30m', '24h', '7d']);
+  });
+});

--- a/tests/alerts/variationMetrics.test.js
+++ b/tests/alerts/variationMetrics.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { collectVariationMetrics, __private__ } from '../../src/alerts/variationMetrics.js';
+
+describe('collectVariationMetrics', () => {
+  it('builds a consolidated variation map across timeframes and horizons', () => {
+    const snapshots = {
+      '4h': { kpis: { var: 0.0123, var24h: 0.045, var7d: 0.1, var30d: -0.05 } },
+      '1h': { kpis: { var: -0.008 } },
+      '30m': { kpis: { var: 0.003 } }
+    };
+
+    const metrics = collectVariationMetrics({ snapshots });
+
+    expect(metrics).toEqual({
+      '4h': 0.0123,
+      '1h': -0.008,
+      '30m': 0.003,
+      '24h': 0.045,
+      '7d': 0.1,
+      '30d': -0.05
+    });
+  });
+
+  it('skips non-finite and missing values', () => {
+    const snapshots = {
+      '4h': { kpis: { var: null, var24h: Number.NaN } },
+      '1h': { kpis: { var: undefined } }
+    };
+
+    const metrics = collectVariationMetrics({ snapshots });
+    expect(metrics).toEqual({});
+  });
+
+  it('prefers 4h snapshot as anchor for higher timeframe metrics', () => {
+    const anchor = { kpis: { var24h: 0.02, var7d: 0.05, var30d: 0.1 } };
+    const metrics = collectVariationMetrics({ snapshots: { '1h': anchor, '15m': { kpis: { var: 0.01 } } } });
+    expect(metrics).toMatchObject({ '24h': 0.02, '7d': 0.05, '30d': 0.1 });
+  });
+});
+
+describe('variationMetrics internals', () => {
+  it('identifies anchor snapshot following priority order', () => {
+    const anchor = { kpis: { var24h: 0.1 } };
+    const result = __private__.resolveAnchorSnapshot({ '15m': {}, '4h': anchor, '1h': {} });
+    expect(result).toBe(anchor);
+  });
+});

--- a/tests/discordBot.test.js
+++ b/tests/discordBot.test.js
@@ -71,6 +71,7 @@ beforeEach(() => {
   for (const key of Object.keys(settingsStore)) {
     delete settingsStore[key];
   }
+  delete process.env.ENABLE_BINANCE_COMMAND;
 });
 
 describe('discord bot interactions', () => {
@@ -266,6 +267,36 @@ describe('discord bot interactions', () => {
     expect(message).toContain('Sem posições de margem abertas.');
   });
 
+  it('informa quando o comando /binance está desativado', async () => {
+    process.env.ENABLE_BINANCE_COMMAND = 'false';
+    const { handleInteraction } = await loadBot();
+
+    const interaction = {
+      isChatInputCommand: () => true,
+      commandName: 'binance',
+      reply: vi.fn(),
+    };
+
+    await handleInteraction(interaction);
+
+    expect(getAccountOverview).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: 'O comando Binance está desativado neste servidor.',
+      ephemeral: true,
+    });
+  });
+
+  it('não registra o comando /binance quando desativado', async () => {
+    process.env.ENABLE_BINANCE_COMMAND = 'false';
+    const { initBot } = await loadBot();
+
+    await initBot();
+
+    expect(setCommandsMock).toHaveBeenCalled();
+    const registered = setCommandsMock.mock.calls[0][0];
+    expect(registered.some(command => command.name === 'binance')).toBe(false);
+  });
+
   it('reports credential issues on /binance command', async () => {
     getAccountOverview.mockRejectedValue(new Error('Missing Binance API credentials'));
     const { handleInteraction } = await loadBot();
@@ -357,6 +388,60 @@ describe('discord bot interactions', () => {
     expect(CFG.minimumProfitThreshold.users).toEqual({ other: 0.09, 'user-77': 0.025 });
     expect(interaction.reply).toHaveBeenCalledWith({
       content: 'Lucro mínimo pessoal atualizado para 2.50%',
+      ephemeral: true,
+    });
+  });
+
+  it('shows the configured minimum profit thresholds through /settings profit view', async () => {
+    settingsStore.minimumProfitThreshold = { default: 0.04, users: { 'user-77': 0.07 } };
+    const { handleInteraction } = await loadBot();
+
+    const interaction = {
+      isChatInputCommand: () => true,
+      commandName: 'settings',
+      options: {
+        getSubcommandGroup: () => 'profit',
+        getSubcommand: () => 'view',
+      },
+      user: { id: 'user-77' },
+      reply: vi.fn(),
+    };
+
+    await handleInteraction(interaction);
+
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: [
+        'Lucro mínimo padrão: 4%',
+        'Seu lucro mínimo: 7.00%',
+        'Valor aplicado nas análises: 7.00%'
+      ].join('\n'),
+      ephemeral: true,
+    });
+  });
+
+  it('falls back to default threshold when personal value is missing on /settings profit view', async () => {
+    settingsStore.minimumProfitThreshold = { default: 0.05, users: {} };
+    const { handleInteraction } = await loadBot();
+
+    const interaction = {
+      isChatInputCommand: () => true,
+      commandName: 'settings',
+      options: {
+        getSubcommandGroup: () => 'profit',
+        getSubcommand: () => 'view',
+      },
+      user: { id: 'user-999' },
+      reply: vi.fn(),
+    };
+
+    await handleInteraction(interaction);
+
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: [
+        'Lucro mínimo padrão: 5%',
+        'Seu lucro mínimo: usando o padrão do servidor',
+        'Valor aplicado nas análises: 5%'
+      ].join('\n'),
       ephemeral: true,
     });
   });

--- a/tests/portfolio/growth.test.js
+++ b/tests/portfolio/growth.test.js
@@ -62,6 +62,14 @@ describe("portfolio growth simulation", () => {
                 chartDirectory: path.join(tmpRoot, "charts"),
                 appendToUploads: true,
             },
+            discord: {
+                enabled: true,
+                mention: "@here",
+                webhookUrl: "",
+                channelId: "",
+                locale: "pt-PT",
+                includeReportLinks: true,
+            },
             strategies: {
                 default: {
                     name: "Balanced",
@@ -106,6 +114,9 @@ describe("portfolio growth simulation", () => {
         expect(fs.existsSync(result?.reports?.progressionPath ?? "")).toBe(true);
         expect(renderPortfolioGrowthChartMock).toHaveBeenCalledOnce();
         expect(result?.uploads).toHaveLength(1);
+        expect(result?.progress?.pct).toBeGreaterThan(0);
+        expect(result?.discord?.message).toContain("Simulação 100€ → 10M€");
+        expect(result?.discordMessage).toBe(result?.discord?.message);
     });
 
     it("retorna null quando o módulo está desativado", async () => {

--- a/tests/portfolio/growthSummary.test.js
+++ b/tests/portfolio/growthSummary.test.js
@@ -1,0 +1,63 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const { buildPortfolioGrowthDiscordMessage } = await import("../../src/portfolio/growthSummary.js");
+
+describe("buildPortfolioGrowthDiscordMessage", () => {
+    const baseSummary = {
+        strategy: "Balanced",
+        finalValue: 25000,
+        investedCapital: 5000,
+        contributionsTotal: 4000,
+        contributionsCount: 40,
+        targetCapital: 10_000_000,
+        targetReached: false,
+        metrics: {
+            totalReturnPct: 4,
+            cagr: 0.76,
+            maxDrawdownPct: 0.28,
+            annualizedVolatility: 0.52,
+            sharpeRatio: 1.2,
+            durationDays: 720,
+        },
+        progress: {
+            pct: 0.0025,
+            remainingCapital: 9_975_000,
+            estimatedYearsToTarget: 8.4,
+        },
+        reports: {
+            summaryPath: path.join(process.cwd(), "reports", "growth", "latest.json"),
+            chartPath: path.join(process.cwd(), "charts", "growth", "portfolio_growth.png"),
+        },
+    };
+
+    it("monta mensagem com métricas principais e links locais", () => {
+        const message = buildPortfolioGrowthDiscordMessage({
+            summary: baseSummary,
+            mention: "@here",
+            locale: "pt-PT",
+            includeReportLinks: true,
+        });
+
+        expect(message).toContain("@here");
+        expect(message).toContain("Simulação 100€ → 10M€ · Balanced");
+        expect(message).toContain("Valor atual:");
+        expect(message).toContain("Meta:");
+        expect(message).toContain("Risco:");
+        expect(message).toContain("Relatórios salvos");
+    });
+
+    it("omite relatórios quando includeReportLinks = false", () => {
+        const message = buildPortfolioGrowthDiscordMessage({
+            summary: baseSummary,
+            includeReportLinks: false,
+        });
+
+        expect(message).not.toContain("Relatórios salvos");
+    });
+
+    it("retorna string vazia para resumo inválido", () => {
+        const message = buildPortfolioGrowthDiscordMessage({ summary: null });
+        expect(message).toBe("");
+    });
+});

--- a/tests/trading/automation.test.js
+++ b/tests/trading/automation.test.js
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const getMarginPositionRiskMock = vi.fn();
+const openPositionMock = vi.fn();
+const closePositionMock = vi.fn();
+
+vi.mock("../../src/trading/binance.js", () => ({
+    getMarginPositionRisk: getMarginPositionRiskMock,
+}));
+
+vi.mock("../../src/trading/executor.js", () => ({
+    openPosition: openPositionMock,
+    closePosition: closePositionMock,
+}));
+
+const loggerMocks = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+
+vi.mock("../../src/logger.js", () => ({
+    logger: loggerMocks,
+    withContext: () => loggerMocks,
+}));
+
+const { CFG } = await import("../../src/config.js");
+const { automateTrading } = await import("../../src/trading/automation.js");
+
+describe("automated trading integration", () => {
+    beforeEach(() => {
+        getMarginPositionRiskMock.mockReset();
+        openPositionMock.mockReset();
+        closePositionMock.mockReset();
+        Object.values(loggerMocks).forEach(mock => mock.mockReset());
+        CFG.trading = {
+            enabled: true,
+            automation: {
+                enabled: true,
+                timeframe: "4h",
+                minConfidence: 0.55,
+                positionPct: 0.05,
+                maxPositions: 3,
+                positionEpsilon: 0.0001,
+            },
+        };
+        CFG.accountEquity = 1000;
+    });
+
+    afterEach(() => {
+        getMarginPositionRiskMock.mockReset();
+        openPositionMock.mockReset();
+        closePositionMock.mockReset();
+        Object.values(loggerMocks).forEach(mock => mock.mockReset());
+    });
+
+    it("skips when trading or automation are disabled", async () => {
+        CFG.trading.enabled = false;
+        const result = await automateTrading({
+            assetKey: "BTC",
+            symbol: "BTCUSDT",
+            timeframe: "4h",
+            decision: { decision: "buy", confidence: 0.9 },
+            posture: { confidence: 0.9 },
+            strategy: { confidence: 0.9 },
+            snapshot: { kpis: { price: 30000 } },
+        });
+        expect(result).toEqual({ skipped: true, reason: "disabled" });
+        expect(getMarginPositionRiskMock).not.toHaveBeenCalled();
+    });
+
+    it("opens a long position when confidence is sufficient", async () => {
+        getMarginPositionRiskMock.mockResolvedValueOnce([]);
+        const result = await automateTrading({
+            assetKey: "BTC",
+            symbol: "BTCUSDT",
+            timeframe: "4h",
+            decision: { decision: "buy", confidence: 0.8 },
+            posture: { confidence: 0.8 },
+            strategy: { confidence: 0.8 },
+            snapshot: { kpis: { price: 30000 } },
+        });
+        expect(result.executed).toBe(true);
+        expect(result.direction).toBe("long");
+        expect(openPositionMock).toHaveBeenCalledTimes(1);
+        const call = openPositionMock.mock.calls[0][0];
+        expect(call.direction).toBe("long");
+        expect(call.quantity).toBeCloseTo((CFG.accountEquity * CFG.trading.automation.positionPct) / 30000, 6);
+        expect(closePositionMock).not.toHaveBeenCalled();
+    });
+
+    it("closes an open position when signal turns flat", async () => {
+        getMarginPositionRiskMock.mockResolvedValueOnce([{ symbol: "BTCUSDT", positionAmt: "0.02" }]);
+        const result = await automateTrading({
+            assetKey: "BTC",
+            symbol: "BTCUSDT",
+            timeframe: "4h",
+            decision: { decision: "hold", confidence: 0.7 },
+            posture: { confidence: 0.7 },
+            strategy: { confidence: 0.7 },
+            snapshot: { kpis: { price: 31000 } },
+        });
+        expect(result.executed).toBe(true);
+        expect(result.action).toBe("close");
+        expect(closePositionMock).toHaveBeenCalledTimes(1);
+        const call = closePositionMock.mock.calls[0][0];
+        expect(call.direction).toBe("long");
+        expect(call.quantity).toBeCloseTo(0.02);
+    });
+
+    it("reverses short positions before opening a long", async () => {
+        getMarginPositionRiskMock.mockResolvedValueOnce([{ symbol: "BTCUSDT", positionAmt: "-0.01" }]);
+        const result = await automateTrading({
+            assetKey: "BTC",
+            symbol: "BTCUSDT",
+            timeframe: "4h",
+            decision: { decision: "buy", confidence: 0.9 },
+            posture: { confidence: 0.9 },
+            strategy: { confidence: 0.9 },
+            snapshot: { kpis: { price: 28000 } },
+        });
+        expect(result.executed).toBe(true);
+        expect(closePositionMock).toHaveBeenCalledTimes(1);
+        expect(openPositionMock).toHaveBeenCalledTimes(1);
+        expect(closePositionMock.mock.calls[0][0].direction).toBe("short");
+        expect(openPositionMock.mock.calls[0][0].direction).toBe("long");
+    });
+
+    it("respects maximum active position limits", async () => {
+        CFG.trading.automation.maxPositions = 1;
+        getMarginPositionRiskMock.mockResolvedValueOnce([
+            { symbol: "ETHUSDT", positionAmt: "0.05" },
+        ]);
+        const result = await automateTrading({
+            assetKey: "BTC",
+            symbol: "BTCUSDT",
+            timeframe: "4h",
+            decision: { decision: "buy", confidence: 0.8 },
+            posture: { confidence: 0.8 },
+            strategy: { confidence: 0.8 },
+            snapshot: { kpis: { price: 29000 } },
+        });
+        expect(result).toEqual({ skipped: true, reason: "maxPositions" });
+        expect(openPositionMock).not.toHaveBeenCalled();
+    });
+
+    it("skips trades when confidence is below the threshold", async () => {
+        getMarginPositionRiskMock.mockResolvedValueOnce([]);
+        const result = await automateTrading({
+            assetKey: "BTC",
+            symbol: "BTCUSDT",
+            timeframe: "4h",
+            decision: { decision: "buy", confidence: 0.3 },
+            posture: { confidence: 0.3 },
+            strategy: { confidence: 0.3 },
+            snapshot: { kpis: { price: 27000 } },
+        });
+        expect(result.reason).toBe("lowConfidence");
+        expect(openPositionMock).not.toHaveBeenCalled();
+    });
+});

--- a/website/docs/guide/binance-credenciais.md
+++ b/website/docs/guide/binance-credenciais.md
@@ -4,7 +4,7 @@ Este guia reúne recomendações de segurança, configuração e uso das funcion
 
 ## Permissões recomendadas
 
-- Crie **duas chaves** quando possível: uma somente leitura (alertas e dashboards) e outra com "Enable Spot & Margin Trading" habilitado para o executor automático.
+- Crie **duas chaves** quando possível: uma somente leitura (alertas e dashboards) e outra com "Enable Spot & Margin Trading" habilitado para o executor automático e as rotinas de abertura/fechamento de posições.
 - Mantenha "Enable Withdrawals" sempre desabilitado — o bot não precisa desta permissão.
 - Restrinja acessos por **IP allowlist**. Quando hospedar o bot em provedores com IP dinâmico, utilize proxies fixos ou VPN corporativa.
 
@@ -19,15 +19,18 @@ Este guia reúne recomendações de segurança, configuração e uso das funcion
 
 1. Atualize o arquivo `.env` com as credenciais desejadas.
 2. Ajuste `config/default.json` ou `config/custom.json` para definir:
+   - `enableBinanceCommand` — liga/desliga o comando `/binance` (pode ser sobrescrito com `ENABLE_BINANCE_COMMAND=false`).
    - `trading.executor.enabled` — liga/desliga ordens reais.
+   - `trading.automation.*` — controla o executor baseado em postura (timeframe monitorado, confiança mínima, sizing e limite de posições simultâneas).
    - `trading.risk.maxDrawdownPercent` e `portfolio.growth.maxDrawdownPercent` — proteções contra quedas.
    - `alerts.thresholds.minimumProfitPercent` — alinhado aos novos comandos `/settings profit`.
 3. Reinicie o bot para que as mudanças de ambiente e config sejam aplicadas.
 
 ## Funcionalidades disponíveis
 
-- **Comando `/binance`**: apresenta saldos spot, métricas de margem e posições abertas com links para a exchange quando disponíveis.
+- **Comando `/binance`** (controlado por `enableBinanceCommand`): apresenta saldos spot, métricas de margem e posições abertas com links para a exchange quando disponíveis.
 - **Executor automático**: envia ordens `MARKET` e `LIMIT` com logs detalhados em `logs/trading.log` e validação de postura bull/bear.
+- **Abertura/fechamento automatizado**: o módulo `src/trading/automation.js` consulta posições de margem (`/sapi/v1/margin/positionRisk`), aplica o limite configurado em `trading.automation.maxPositions` e inverte posições quando a estratégia alterna entre bull/bear.
 - **Simulações e forecasting**: utilizam dados da Binance para projetar crescimento de portfólio e prever fechamentos, salvando históricos em `reports/`.
 - **Alertas enriquecidos**: variáveis de ambiente e configurações personalizadas refletem imediatamente nas mensagens enviadas.
 
@@ -36,7 +39,7 @@ Este guia reúne recomendações de segurança, configuração e uso das funcion
 - [ ] IP allowlist configurada para as chaves com permissão de trade.
 - [ ] Secrets armazenados apenas em ambientes protegidos (sem commits, screenshots ou tickets).
 - [ ] Rotação periódica das chaves documentada.
-- [ ] Logs de execução monitorados (falhas de assinatura são registradas em `trading.binance`).
+- [ ] Logs de execução monitorados (falhas de assinatura são registradas em `trading.binance` e decisões em `trading.automation`).
 - [ ] Alertas de execução automatizados com notificações em canais privados do Discord.
 
 Manter essas práticas reduz a superfície de ataque e garante que as automações recém-adicionadas operem de forma segura.

--- a/website/docs/guide/introducao.md
+++ b/website/docs/guide/introducao.md
@@ -51,3 +51,62 @@ npm test
 ```
 
 Com isso você valida integrações antes de hospedar o serviço em produção.
+
+## Ajustando o lucro mínimo por comando
+
+O bot permite ajustar um alvo mínimo de lucro para filtrar oportunidades de trade e destacar alertas realmente relevantes:
+
+- `/settings profit view` exibe o valor padrão do servidor, o seu limite pessoal (se existir) e o alvo efetivo aplicado nas análises.
+- `/settings profit default value:<percentual>` define o lucro mínimo global em porcentagem (por exemplo, `5` para 5%).
+- `/settings profit personal value:<percentual>` grava o seu limite individual, sobrescrevendo o padrão para respostas das interações.
+
+Os valores ficam persistidos em `data/settings.json` e influenciam recomendações como o alerta de níveis de trade, que agora sinaliza quando o alvo projetado está abaixo do limite configurado.
+
+## Variação por timeframe nos alertas
+
+Os alertas consolidados passaram a incluir uma linha dedicada às variações de preço por timeframe. Sempre que novas métricas são calculadas, o bot combina os movimentos recentes (5m, 15m, 30m, 45m, 1h, 4h) com janelas mais longas (24h, 7d e 30d) para oferecer contexto imediato sobre o momentum do ativo.
+
+- O módulo `varAlert` agrega os percentuais em uma única mensagem, respeitando a ordem configurada em `TIMEFRAMES` e destacando as janelas diárias e semanais.
+- A mensagem final no Discord inclui a lista `_Variações: …_`, garantindo que cada ativo mostre como está performando em múltiplos horizontes de tempo.
+
+Essa visão unificada facilita priorizar oportunidades e entender se um movimento forte em timeframes curtos está alinhado (ou não) com a tendência de médio prazo.
+
+## Decisão buy/sell/hold por timeframe
+
+Cada bloco de alertas agora inclui uma linha explícita de decisão (`Decisão: …`) logo abaixo de cada item listado. O bot cruza o resultado do avaliador de postura de mercado (`src/trading/posture.js`) com a estratégia ativa para traduzir os indicadores em uma recomendação prática:
+
+- **Buy (🟢)** quando a estratégia sugere posição comprada com confiança suficiente.
+- **Sell (🔴)** caso a leitura aponte para venda/posição vendida.
+- **Hold (🟡)** se o cenário estiver neutro ou com convicção insuficiente.
+
+Além do rótulo, a linha de decisão mostra a postura dominante (alta, baixa ou neutra), o nível de confiança e os principais motivos calculados pelo motor de postura. Isso facilita validar rapidamente o racional por trás de cada alerta sem abrir relatórios adicionais.
+
+## Alertas organizados por ativo
+
+Para tornar o feed de alertas mais digerível, as notificações agregadas agora são ordenadas por ativo antes de chegarem ao Discord. O dispatcher reúne todos os payloads gerados durante o ciclo e aplica duas regras:
+
+- Se o ativo tiver metadados de capitalização (`marketCapRank`) definidos em `src/assets.js`, a ordenação prioriza os mercados mais relevantes (rank 1 primeiro, rank 2 em seguida, etc.).
+- Na ausência desse dado, os ativos são listados alfabeticamente, garantindo previsibilidade mesmo para tickers personalizados ou recém-adicionados.
+
+Com essa organização, fica mais simples acompanhar o que está acontecendo com BTC, ETH e demais moedas sem saltos ou inversões de ordem no canal de alertas.
+
+## Forecasts de fechamento e gráficos históricos
+
+O módulo de forecasting (em `src/forecasting.js`) calcula uma projeção do próximo preço de fechamento para cada timeframe monitorado utilizando regressão linear. A cada execução do bot:
+
+- Os resultados são persistidos em `reports/forecasts/<ATIVO>/<timeframe>.json`, mantendo um histórico com data da previsão, confiança, delta e erro em relação ao fechamento observado posteriormente.
+- Quando `forecasting.charts.enabled` está ativo, um gráfico comparativo é renderizado em `charts/forecasts/`, destacando o candle mais recente e o ponto previsto.
+- A linha "Previsão" aparece nos alertas do Discord logo após o cabeçalho de cada timeframe, mostrando o preço estimado, variação esperada, confiança percentual, alvo temporal (convertido para o fuso definido em `CFG.tz`) e, quando disponível, a precisão da previsão anterior.
+- Se `forecasting.charts.appendToUploads` for verdadeiro, as imagens geradas são anexadas automaticamente ao mesmo post dos gráficos tradicionais.
+
+Os parâmetros padrão (lookback, histórico mínimo, limite de retenção e diretórios) podem ser ajustados em `config/default.json` ou sobrescritos via variáveis de ambiente (`FORECASTING_*`). Isso facilita calibrar a janela de análise conforme a volatilidade de cada exchange e manter os artefatos fora do versionamento.
+
+## Simulador 100€ → 10M€ com resumos automáticos
+
+O job `runPortfolioGrowthSimulation` (em `src/portfolio/growth.js`) roda diariamente um backtest de longo prazo para acompanhar a jornada de €100 até €10 milhões. O simulador considera alocações configuráveis, aportes periódicos, controles de risco (drawdown, stop loss, take profit) e rebalanceamentos automáticos, salvando JSONs em `reports/growth/` e gráficos em `charts/growth/`.
+
+- Defina pesos por ativo em `portfolioGrowth.strategies` e personalize aportes, slippage e janelas históricas em `portfolioGrowth.simulation`.
+- A cada execução, o bot gera métricas como retorno acumulado, CAGR, volatilidade anualizada, Sharpe ratio e data estimada para alcançar a meta com base no crescimento composto.
+- Ative `portfolioGrowth.discord.enabled` para receber um resumo no Discord com menção opcional (`@here`, cargos ou usuários), progresso percentual, capital investido e os links locais dos relatórios gerados.
+
+O módulo respeita diretórios e webhooks definidos em variáveis `PORTFOLIO_*`, garantindo que nenhum arquivo temporário seja versionado e que as notificações possam ser direcionadas a canais específicos do servidor.

--- a/website/docs/guide/portfolio-growth.md
+++ b/website/docs/guide/portfolio-growth.md
@@ -60,6 +60,14 @@ Trecho relevante de `config/default.json`:
     "chartDirectory": "charts/growth",
     "appendToUploads": false
   },
+  "discord": {
+    "enabled": false,
+    "mention": "",
+    "webhookUrl": "",
+    "channelId": "",
+    "locale": "pt-PT",
+    "includeReportLinks": true
+  },
   "strategies": {
     "default": {
       "name": "Base Rebalance",
@@ -89,6 +97,9 @@ Trecho relevante de `config/default.json`:
 | `PORTFOLIO_REBALANCE_INTERVAL`, `PORTFOLIO_REBALANCE_TOLERANCE` | Personalizam a cadência e a tolerância do rebalance. |
 | `PORTFOLIO_ALLOCATION` | Permite informar pesos customizados (`BTC:0.5,ETH:0.3,SOL:0.2`). |
 | `PORTFOLIO_REPORT_DIR` / `PORTFOLIO_CHART_DIR` | Sobrescrevem onde salvar JSONs e PNGs. |
+| `PORTFOLIO_DISCORD_ENABLED` / `PORTFOLIO_DISCORD_WEBHOOK` | Ativam o resumo diário no Discord e definem um webhook dedicado. |
+| `PORTFOLIO_DISCORD_CHANNEL` / `PORTFOLIO_DISCORD_MENTION` | Ajustam o canal para rate limiting e mencionam `@here`, cargos ou usuários. |
+| `PORTFOLIO_DISCORD_LOCALE` / `PORTFOLIO_DISCORD_INCLUDE_REPORTS` | Controlam o idioma e se links locais são anexados ao texto. |
 
 ## Artefatos gerados
 
@@ -100,6 +111,32 @@ Quando o módulo está ativo (`portfolioGrowth.enabled = true`):
 - `charts/growth/portfolio_growth_<timestamp>.png`: gráfico com valor do portfólio, capital investido, caixa e drawdown.
 
 Se `reporting.appendToUploads` estiver habilitado, o gráfico também é publicado no canal de charts configurado no Discord.
+
+## Resumo automático no Discord
+
+Configure o bloco `portfolioGrowth.discord` para que o bot envie um texto conciso com o andamento rumo aos €10 milhões. O resumo inclui valor atual, CAGR, retorno acumulado, aportes realizados, progresso percentual da meta e indicadores de risco.
+
+```text
+@here
+**Simulação 100€ → 10M€ · Base Rebalance**
+- Valor atual: €12 345,00 (+123,45% total | CAGR 47,20%)
+- Capital investido: €1 200,00 (aportes €1 100,00 em 12 contribuições)
+- Meta: €10 000 000,00 · progresso 0,12% · falta €9 987 655,00 · projeção 8,4 anos
+- Risco: drawdown máx 32,00% · vol anual 54,00% · Sharpe 1,20
+- Janela analisada: 3,0 anos (1 095 dias)
+- Relatórios salvos (0,12% da meta): `reports/growth/latest.json`, `charts/growth/portfolio_growth_2024-02-01.png`
+```
+
+Ative o fluxo com as variáveis:
+
+```bash
+export PORTFOLIO_GROWTH_ENABLED=true
+export PORTFOLIO_DISCORD_ENABLED=true
+export PORTFOLIO_DISCORD_WEBHOOK="https://discord.com/api/webhooks/..."
+export PORTFOLIO_DISCORD_MENTION="@here"
+```
+
+O módulo respeita o rate limit do canal informado e reutiliza `CFG.webhook` como fallback quando o webhook dedicado não é definido.
 
 ## Próximos passos sugeridos
 


### PR DESCRIPTION
## Summary
- add a configurable `portfolioGrowth.discord` block with environment overrides so operators can enable webhook posts for the 100€ → 10M€ simulator
- enrich the growth simulation with progress metrics and a Discord-friendly summary message, publishing it when the feature is toggled on
- document the Discord workflow, cover the formatter with unit tests, and mark the wishlist entry as complete

## Testing
- npm run test
- npm run test:coverage
- npm run test:chart


------
https://chatgpt.com/codex/tasks/task_e_68d463d40224832681f679359f4b1ace