### PR TITLE
Gracefully degrade Binance account view and add release notes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Guia de Contribuição
+
+Este documento resume o fluxo esperado para desenvolver novas funcionalidades e garantir que o repositório permaneça alinhado às diretrizes do projeto.
+
+## Preparação do ambiente
+
+1. Instale as dependências do Node:
+   ```bash
+   npm install
+   ```
+2. Copie o arquivo de variáveis e configure credenciais locais:
+   ```bash
+   cp .env.example .env
+   ```
+3. Utilize o utilitário de configuração para validar segredos e sobrepor valores sem editar JSON manualmente:
+   ```bash
+   npm exec config-cli list
+   npm exec config-cli set alerts.modules.rsi true
+   ```
+
+## Fluxo de trabalho recomendado
+
+1. **Linter e formatação** — Execute `npm run lint` para garantir sintaxe ESM, indentação de 4 espaços e convenções de aspas (imports com aspas duplas; logs com aspas simples). Use `npm run lint:fix` para aplicar correções automáticas quando disponíveis.
+2. **Testes unitários** — Rode `npm test` durante o desenvolvimento. Antes de abrir PR, gere também `npm run test:coverage` para validar os thresholds mínimos definidos no `vitest.config.js`.
+3. **Documentação** — Sempre que APIs, comandos ou fluxos mudarem, atualize `README.md` e regenere a documentação com `npm run docs`. Para iterar na documentação do site, utilize `npm run site:dev`.
+4. **Limpeza de artefatos** — Evite subir diretórios gerados (`coverage/`, `charts/`, `reports/`, `logs/`). Use `npm run cleanup:reports` antes de commitar quando arquivos temporários forem criados.
+5. **Commits** — Utilize mensagens imperativas descrevendo a mudança (ex.: `Adiciona verificação de cache da Binance`). Squashe commits intermediários barulhentos antes de abrir o PR.
+
+## Estrutura de testes
+
+- Crie arquivos em `tests/` espelhando o caminho de origem (ex.: `src/data/binance.js` → `tests/data/binance.test.js`).
+- Utilize o Vitest para mocks (`vi.mock`) e timers (`vi.useFakeTimers`), resetando estados compartilhados entre casos.
+- Registre lacunas de cobertura deliberadas na descrição do PR para manter rastreabilidade.
+
+Seguindo estes passos, novas contribuições permanecerão consistentes com as expectativas de qualidade do projeto.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,149 @@
+import js from "@eslint/js";
+import globals from "globals";
+
+const loggingMethods = new Set(["debug", "info", "warn", "error", "trace"]);
+
+const stylePlugin = {
+    rules: {
+        "import-double-quotes": {
+            meta: {
+                type: "layout",
+                docs: {
+                    description: "Garante aspas duplas em imports para seguir a convenção do projeto.",
+                },
+                fixable: "code",
+                schema: [],
+                messages: {
+                    expected: "Use aspas duplas nas declarações de import.",
+                },
+            },
+            create(context) {
+                return {
+                    ImportDeclaration(node) {
+                        const source = node.source;
+                        if (!source || source.type !== "Literal" || typeof source.value !== "string") {
+                            return;
+                        }
+                        const raw = context.sourceCode.getText(source);
+                        if (!raw.startsWith("\"")) {
+                            context.report({
+                                node: source,
+                                messageId: "expected",
+                                fix(fixer) {
+                                    const escaped = source.value.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
+                                    return fixer.replaceText(source, `"${escaped}"`);
+                                },
+                            });
+                        }
+                    },
+                };
+            },
+        },
+        "log-single-quotes": {
+            meta: {
+                type: "layout",
+                docs: {
+                    description: "Garante aspas simples em mensagens de log para manter consistência com o logger.",
+                },
+                fixable: "code",
+                schema: [],
+                messages: {
+                    expected: "Use aspas simples nas mensagens enviadas ao logger.",
+                },
+            },
+            create(context) {
+                const sourceCode = context.sourceCode;
+                return {
+                    CallExpression(node) {
+                        const callee = node.callee;
+                        if (!callee || callee.type !== "MemberExpression") {
+                            return;
+                        }
+                        const property = callee.property;
+                        if (!property || property.type !== "Identifier" || !loggingMethods.has(property.name)) {
+                            return;
+                        }
+                        for (const arg of node.arguments) {
+                            if (arg.type !== "Literal" || typeof arg.value !== "string") {
+                                continue;
+                            }
+                            const raw = sourceCode.getText(arg);
+                            if (!raw.startsWith("'")) {
+                                const escaped = arg.value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+                                context.report({
+                                    node: arg,
+                                    messageId: "expected",
+                                    fix(fixer) {
+                                        return fixer.replaceText(arg, `'${escaped}'`);
+                                    },
+                                });
+                            }
+                        }
+                    },
+                };
+            },
+        },
+    },
+};
+
+const baseGlobals = {
+    ...globals.node,
+    ...globals.es2021,
+};
+
+export default [
+    {
+        ignores: [
+            "**/node_modules/**",
+            "coverage/**",
+            "charts/**",
+            "reports/**",
+            "docs/**",
+            "website/**",
+        ],
+    },
+    {
+        files: [
+            "eslint.config.js",
+            "tests/ai.test.js",
+            "tests/data/**/*.js",
+            "src/data/**/*.js",
+        ],
+        languageOptions: {
+            ecmaVersion: 2022,
+            sourceType: "module",
+            globals: baseGlobals,
+        },
+        plugins: {
+            style: stylePlugin,
+        },
+        rules: {
+            ...js.configs.recommended.rules,
+            indent: ["error", 4, { SwitchCase: 1 }],
+            "no-var": "error",
+            "prefer-const": ["error", { destructuring: "all" }],
+            semi: ["error", "always"],
+            "style/import-double-quotes": "error",
+            "style/log-single-quotes": "error",
+        },
+    },
+    {
+        files: ["tests/**/*.js"],
+        languageOptions: {
+            ecmaVersion: 2022,
+            sourceType: "module",
+            globals: {
+                ...baseGlobals,
+                vi: true,
+                describe: true,
+                it: true,
+                expect: true,
+                beforeEach: true,
+                afterEach: true,
+            },
+        },
+        rules: {
+            "no-unused-expressions": "off",
+        },
+    },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,8 +33,11 @@
         "config-cli": "bin/config-cli.js"
       },
       "devDependencies": {
+        "@eslint/js": "^9.9.0",
         "@vitest/coverage-v8": "^3.2.4",
         "clean-jsdoc-theme": "^4.3.0",
+        "eslint": "^9.9.0",
+        "globals": "^15.9.0",
         "jsdoc": "^4.0.4",
         "vitepress": "^1.3.3",
         "vitest": "^3.2.4"
@@ -1005,6 +1008,273 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.6",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
+      "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
+      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.36.0.tgz",
+      "integrity": "sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
+      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.15.2",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@iconify-json/simple-icons": {
       "version": "1.2.53",
       "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.53.tgz",
@@ -1918,6 +2188,13 @@
       "integrity": "sha512-EqX+YQxINb+MeXaIqYDASb6U6FCHbWjkj4a1CKDBks3d/QiB2+PqBLyO72vLDgAO1wUI4O+9gweRcQK11bTL/w==",
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/linkify-it": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
@@ -2526,6 +2803,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2533,6 +2820,23 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/algoliasearch": {
@@ -3186,6 +3490,13 @@
         "node": ">=14"
       }
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/copy-anything": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
@@ -3320,6 +3631,13 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/degenerator": {
       "version": "5.0.1",
@@ -3655,6 +3973,152 @@
         "source-map": "~0.6.1"
       }
     },
+    "node_modules/eslint": {
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.36.0.tgz",
+      "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.0",
+        "@eslint/config-helpers": "^0.3.1",
+        "@eslint/core": "^0.15.2",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.36.0",
+        "@eslint/plugin-kit": "^0.3.5",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -3666,6 +4130,32 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+      "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/estraverse": {
@@ -3774,6 +4264,20 @@
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-redact": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.5.0.tgz",
@@ -3809,6 +4313,57 @@
           "optional": true
         }
       }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/focus-trap": {
       "version": "7.6.5",
@@ -4018,6 +4573,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {
@@ -4247,6 +4828,16 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -4261,6 +4852,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
       }
     },
     "node_modules/inherits": {
@@ -4290,6 +4891,16 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "license": "MIT"
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -4297,6 +4908,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-what": {
@@ -4460,10 +5084,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsonfile": {
@@ -4477,6 +5122,16 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/klaw": {
@@ -4499,6 +5154,20 @@
         "graceful-fs": "^4.1.11"
       }
     },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -4515,10 +5184,33 @@
         "uc.micro": "^2.0.0"
       }
     },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.snakecase": {
@@ -4937,6 +5629,13 @@
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "license": "MIT"
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/netmask": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
@@ -5058,6 +5757,56 @@
         }
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/pac-proxy-agent": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
@@ -5147,6 +5896,16 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-key": {
@@ -5376,6 +6135,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -5466,6 +6235,16 @@
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/punycode.js": {
@@ -6385,6 +7164,19 @@
         "node": "*"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/typed-query-selector": {
       "version": "2.12.0",
       "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
@@ -6515,6 +7307,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -7342,6 +8144,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -7478,6 +8290,19 @@
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "test:chart": "node tests/render-chart.js",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage --hook-timeout=20000",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "cleanup:reports": "node bin/cleanup-reports.js",
     "docs": "jsdoc -c jsdoc.json && node bin/strip-doc-fonts.js",
     "site:dev": "vitepress dev website/docs",
@@ -42,7 +44,10 @@
   },
   "devDependencies": {
     "@vitest/coverage-v8": "^3.2.4",
+    "@eslint/js": "^9.9.0",
     "clean-jsdoc-theme": "^4.3.0",
+    "eslint": "^9.9.0",
+    "globals": "^15.9.0",
     "jsdoc": "^4.0.4",
     "vitepress": "^1.3.3",
     "vitest": "^3.2.4"

--- a/src/data/binance.js
+++ b/src/data/binance.js
@@ -58,7 +58,7 @@ export async function fetchOHLCV(symbol, interval) {
             return axios.get(url);
         });
         if (CFG.debug) {
-            log.info({ fn: 'fetchOHLCV', data }, "OHLCV data");
+            log.info({ fn: 'fetchOHLCV', data }, 'OHLCV data');
         }
         const result = data.map(c => ({
             t: new Date(c[0]),
@@ -94,7 +94,7 @@ export async function fetchDailyCloses(symbol, days = 32) {
             return axios.get(url);
         });
         if (CFG.debug) {
-            log.info({ fn: 'fetchDailyCloses', data }, "Daily closes data");
+            log.info({ fn: 'fetchDailyCloses', data }, 'Daily closes data');
         }
         const result = data.map(c => ({ t: new Date(c[0]), c: +c[4], v: +c[5] }));
         cache.set(cacheKey, result);

--- a/src/data/economic.js
+++ b/src/data/economic.js
@@ -22,7 +22,7 @@ export async function fetchEconomicEvents() {
                 impact: e.impact
             }));
     } catch (err) {
-        log.error({ fn: 'fetchEconomicEvents', err }, "Error fetching economic events");
+        log.error({ fn: 'fetchEconomicEvents', err }, 'Error fetching economic events');
         return [];
     }
 }

--- a/src/data/newsapi.js
+++ b/src/data/newsapi.js
@@ -20,7 +20,7 @@ export async function searchNews(asset) {
             description: a.description || "",
         }));
     } catch (error) {
-        log.error({ fn: 'searchNews', err: error }, "Error fetching news");
+        log.error({ fn: 'searchNews', err: error }, 'Error fetching news');
         return [];
     }
 }

--- a/tests/ai.test.js
+++ b/tests/ai.test.js
@@ -1,0 +1,164 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+const mockCFG = {
+    debug: false,
+    openrouterApiKey: null,
+    openrouterModel: "gpt-4",
+};
+
+const mockAssets = [];
+
+const buildCandle = (index) => ({
+    t: new Date(1700000000000 + index * 60_000),
+    o: 100 + index,
+    h: 101 + index,
+    l: 99 + index,
+    c: 100 + index,
+    v: 10 + index,
+});
+
+const hourlyCandles = Array.from({ length: 260 }, (_, i) => buildCandle(i));
+const dailyCandles = Array.from({ length: 60 }, (_, i) => ({
+    t: new Date(1700000000000 + i * 86_400_000),
+    o: 100 + i,
+    h: 105 + i,
+    l: 95 + i,
+    c: 100 + i,
+    v: 50 + i,
+}));
+
+const indicatorsStub = {
+    sma: vi.fn(() => Array.from({ length: 260 }, () => 100)),
+    rsi: vi.fn(() => Array.from({ length: 260 }, () => 55)),
+    macd: vi.fn(() => ({
+        macd: Array.from({ length: 260 }, () => 1),
+        signal: Array.from({ length: 260 }, () => 0.5),
+        hist: Array.from({ length: 260 }, () => 0.25),
+    })),
+    bollinger: vi.fn(() => ({
+        upper: Array.from({ length: 260 }, () => 120),
+        lower: Array.from({ length: 260 }, () => 80),
+        mid: Array.from({ length: 260 }, () => 100),
+    })),
+    bollWidth: vi.fn(() => Array.from({ length: 260 }, () => 0.4)),
+    atr14: vi.fn(() => Array.from({ length: 260 }, () => 1.5)),
+    crossUp: vi.fn(() => false),
+    crossDown: vi.fn(() => false),
+    parabolicSAR: vi.fn(() => Array.from({ length: 260 }, () => 90)),
+    semaforo: vi.fn(() => "🟢"),
+    isBBSqueeze: vi.fn(() => false),
+    sparkline: vi.fn(() => "▁▃▅▇"),
+    volumeDivergence: vi.fn(() => Array.from({ length: 260 }, () => 0.1)),
+    trendFromMAs: vi.fn(() => 1),
+    scoreHeuristic: vi.fn(() => 60),
+    vwap: vi.fn(() => Array.from({ length: 260 }, () => 100)),
+    ema: vi.fn(() => Array.from({ length: 260 }, () => 100)),
+    stochastic: vi.fn(() => ({
+        k: Array.from({ length: 260 }, () => 70),
+        d: Array.from({ length: 260 }, () => 65),
+    })),
+    williamsR: vi.fn(() => Array.from({ length: 260 }, () => -20)),
+    cci: vi.fn(() => Array.from({ length: 260 }, () => 30)),
+    obv: vi.fn(() => Array.from({ length: 260 }, () => 10)),
+};
+
+vi.mock("../src/config.js", () => ({ CFG: mockCFG }));
+vi.mock("../src/assets.js", () => ({ ASSETS: mockAssets }));
+vi.mock("../src/data/binance.js", () => ({
+    fetchOHLCV: vi.fn(async (symbol, timeframe) => {
+        if (symbol === "EMPTY") {
+            return [];
+        }
+        return timeframe === "1d" ? dailyCandles : hourlyCandles;
+    }),
+}));
+vi.mock("../src/news.js", () => ({
+    getAssetNews: vi.fn(async ({ symbol }) => ({
+        summary: `News for ${symbol}`,
+        weightedSentiment: 0.32,
+    })),
+}));
+vi.mock("../src/websearch.js", () => ({
+    searchWeb: vi.fn(async (query) => [`Snippet about ${query}`]),
+}));
+vi.mock("../src/alerts.js", () => ({
+    buildAlerts: vi.fn(async () => [{ id: "alert-1" }]),
+    formatAlertMessage: vi.fn(() => "Mock alert"),
+}));
+vi.mock("../src/logger.js", () => {
+    const sink = {
+        info: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+    };
+    return {
+        logger: sink,
+        withContext: vi.fn(() => sink),
+    };
+});
+vi.mock("../src/indicators.js", () => indicatorsStub);
+vi.mock("openai", () => ({
+    default: class {
+        constructor() {
+            this.chat = {
+                completions: {
+                    create: vi.fn(async () => ({
+                        choices: [
+                            {
+                                message: {
+                                    content: "AI verdict",
+                                },
+                            },
+                        ],
+                    })),
+                },
+            };
+        }
+    },
+}));
+
+beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockAssets.length = 0;
+    mockCFG.openrouterApiKey = null;
+    mockCFG.openrouterModel = "gpt-4";
+});
+
+describe("ai module", () => {
+    it("throws when OpenRouter API key is missing", async () => {
+        const { callOpenRouter } = await import("../src/ai.js");
+        await expect(callOpenRouter([{ role: "user", content: "hello" }])).rejects.toThrow("OpenRouter API key missing");
+    });
+
+    it("invokes OpenRouter when credentials are configured", async () => {
+        mockCFG.openrouterApiKey = "token";
+        const { callOpenRouter } = await import("../src/ai.js");
+        const result = await callOpenRouter([{ role: "user", content: "hello" }]);
+        expect(result).toBe("AI verdict");
+    });
+
+    it("produces fallback content when asset lacks Binance symbol", async () => {
+        mockAssets.push({ key: "NO_BINANCE", binance: null });
+        const { runAgent } = await import("../src/ai.js");
+        const output = await runAgent();
+        expect(output).toContain("No Binance symbol configured.");
+    });
+
+    it("skips assets that return no candles", async () => {
+        mockAssets.push({ key: "EMPTY", binance: "EMPTY" });
+        const { runAgent } = await import("../src/ai.js");
+        const output = await runAgent();
+        expect(output).toContain("No candle data.");
+    });
+
+    it("combines indicators, alerts and context when data is available", async () => {
+        mockAssets.push({ key: "BTC", binance: "BTCUSDT" });
+        const { runAgent } = await import("../src/ai.js");
+        const output = await runAgent();
+        expect(output).toContain("**Alert Status:**");
+        expect(output).toContain("Mock alert");
+        expect(output).toContain("_This report is for educational purposes only");
+    });
+});

--- a/tests/data/binance.test.js
+++ b/tests/data/binance.test.js
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockCFG = {
+    binanceCacheTTL: 5,
+    debug: false,
+};
+
+const axiosGet = vi.fn();
+const fetchWithRetry = vi.fn(async (fn) => fn());
+const recordPerf = vi.fn();
+
+vi.mock("../../src/config.js", () => ({ CFG: mockCFG }));
+vi.mock("axios", () => ({ default: { get: axiosGet } }));
+vi.mock("../../src/utils.js", () => ({ fetchWithRetry }));
+vi.mock("../../src/perf.js", () => ({ recordPerf }));
+vi.mock("../../src/logger.js", () => {
+    const sink = {
+        info: vi.fn(),
+        debug: vi.fn(),
+        error: vi.fn(),
+    };
+    return {
+        logger: sink,
+        withContext: vi.fn(() => sink),
+    };
+});
+
+const mockCandles = [
+    [1700000000000, "100", "110", "90", "105", "1200"],
+    [1700000060000, "105", "112", "99", "108", "980"],
+];
+
+beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    axiosGet.mockResolvedValue({ data: mockCandles });
+});
+
+describe("src/data/binance", () => {
+    it("fetches OHLCV data and caches the response", async () => {
+        const { fetchOHLCV } = await import("../../src/data/binance.js");
+        const first = await fetchOHLCV("BTCUSDT", "1h");
+        const second = await fetchOHLCV("BTCUSDT", "1h");
+
+        expect(first).toHaveLength(2);
+        expect(second).toBe(first);
+        expect(axiosGet).toHaveBeenCalledTimes(1);
+        expect(recordPerf).toHaveBeenCalledWith("fetchOHLCV", expect.any(Number));
+    });
+
+    it("marks Binance as offline when network errors occur", async () => {
+        const offlineError = Object.assign(new Error("offline"), { code: "ENETUNREACH" });
+        axiosGet.mockRejectedValueOnce(offlineError);
+        const { fetchOHLCV } = await import("../../src/data/binance.js");
+
+        await expect(fetchOHLCV("BTCUSDT", "1h")).rejects.toThrow("offline");
+        await expect(fetchOHLCV("BTCUSDT", "1h")).rejects.toThrow("Binance API unavailable");
+    });
+
+    it("fetches and caches daily closes independently", async () => {
+        const { fetchDailyCloses } = await import("../../src/data/binance.js");
+        const first = await fetchDailyCloses("BTCUSDT", 10);
+        const second = await fetchDailyCloses("BTCUSDT", 10);
+
+        expect(first[0]).toMatchObject({ c: 105 });
+        expect(second).toBe(first);
+        expect(axiosGet).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/minimumProfit.test.js
+++ b/tests/minimumProfit.test.js
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const CFG = { minimumProfitThreshold: { default: 0.02, users: {} } };
+const settingsStore = {};
+const getSettingMock = vi.fn((key, fallback) => (key in settingsStore ? settingsStore[key] : fallback));
+const setSettingMock = vi.fn((key, value) => {
+    settingsStore[key] = value;
+    return value;
+});
+
+vi.mock("../src/config.js", () => ({ CFG }));
+vi.mock("../src/settings.js", () => ({
+    getSetting: getSettingMock,
+    setSetting: setSettingMock,
+}));
+
+describe("minimum profit thresholds", () => {
+    beforeEach(() => {
+        vi.resetModules();
+        Object.keys(settingsStore).forEach(key => { delete settingsStore[key]; });
+        CFG.minimumProfitThreshold = { default: 0.02, users: {} };
+        getSettingMock.mockClear();
+        setSettingMock.mockClear();
+    });
+
+    it("evaluates trades against the global threshold", async () => {
+        const {
+            setDefaultMinimumProfit,
+            meetsMinimumProfitThreshold,
+        } = await import("../src/minimumProfit.js");
+
+        setDefaultMinimumProfit(0.08);
+        expect(meetsMinimumProfitThreshold({ entry: 100, target: 104 })).toBe(false);
+        expect(meetsMinimumProfitThreshold({ entry: 100, target: 110 })).toBe(true);
+    });
+
+    it("prefers the user-specific threshold when available", async () => {
+        const {
+            setDefaultMinimumProfit,
+            setPersonalMinimumProfit,
+            meetsMinimumProfitThreshold,
+        } = await import("../src/minimumProfit.js");
+
+        setDefaultMinimumProfit(0.03);
+        setPersonalMinimumProfit("user-1", 0.12);
+
+        expect(meetsMinimumProfitThreshold({ entry: 100, target: 107, userId: "user-1" })).toBe(false);
+        expect(meetsMinimumProfitThreshold({ entry: 100, target: 115, userId: "user-1" })).toBe(true);
+    });
+
+    it("honours ad-hoc thresholds passed to the helper", async () => {
+        const { meetsMinimumProfitThreshold } = await import("../src/minimumProfit.js");
+
+        expect(meetsMinimumProfitThreshold({ entry: 100, target: 105, threshold: 0.02 })).toBe(true);
+        expect(meetsMinimumProfitThreshold({ entry: 100, target: 101, threshold: 0.02 })).toBe(false);
+    });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,44 +1,41 @@
-import { defineConfig } from 'vitest/config';
-
-const isCI = process.env.CI === 'true';
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-  test: {
-    coverage: {
-      reporter: ['text', 'lcov'],
-      include: ['src/**/*.js'],
-      exclude: [
-        '**/node_modules/**',
-        'website/**',
-        'docs/**',
-        'charts/**',
-        'bin/**',
-        'reports/**',
-        'src/ai.js',
-        'src/chart.js',
-        'src/config.js',
-        'src/discord.js',
-        'src/discordBot.js',
-        'src/discordRateLimit.js',
-        'src/index.js',
-        'src/limit.js',
-        'src/logger.js',
-        'src/monitor.js',
-        'src/monthlyReport.js',
-        'src/news.js',
-        'src/newsCache.js',
-        'src/perf.js',
-        'src/websearch.js',
-        'src/weeklySnapshots.js',
-        'src/data/**',
-        'src/trading/**',
-      ],
-      thresholds: isCI
-        ? undefined
-        : {
-            statements: 80,
-            branches: 60,
-          },
+    test: {
+        coverage: {
+            reporter: ["text", "lcov"],
+            include: ["src/**/*.js"],
+            exclude: [
+                "**/node_modules/**",
+                "website/**",
+                "docs/**",
+                "charts/**",
+                "bin/**",
+                "reports/**",
+                "src/ai.js",
+                "src/chart.js",
+                "src/config.js",
+                "src/discord.js",
+                "src/discordBot.js",
+                "src/discordRateLimit.js",
+                "src/index.js",
+                "src/limit.js",
+                "src/logger.js",
+                "src/monitor.js",
+                "src/monthlyReport.js",
+                "src/news.js",
+                "src/newsCache.js",
+                "src/perf.js",
+                "src/websearch.js",
+                "src/weeklySnapshots.js",
+                "src/trading/**",
+            ],
+            thresholds: {
+                statements: 80,
+                branches: 60,
+                functions: 75,
+                lines: 80,
+            },
+        },
     },
-  },
 });

--- a/website/docs/.vitepress/config.ts
+++ b/website/docs/.vitepress/config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
     nav: [
       { text: 'Início', link: '/' },
       { text: 'Guia rápido', link: '/guide/introducao' },
+      { text: 'Notas de versão', link: '/guide/releases' },
       { text: 'Identidade visual', link: '/guide/identidade-visual' }
     ],
     sidebar: {
@@ -50,7 +51,8 @@ export default defineConfig({
             { text: 'Introdução', link: '/guide/introducao' },
             { text: 'Deploy no Discord', link: '/guide/deploy-discord' },
             { text: 'Hospedagem na GitHub Pages', link: '/guide/github-pages' },
-            { text: 'Identidade visual e assets', link: '/guide/identidade-visual' }
+            { text: 'Identidade visual e assets', link: '/guide/identidade-visual' },
+            { text: 'Release Notes', link: '/guide/releases' }
           ]
         }
       ]

--- a/website/docs/guide/binance-credenciais.md
+++ b/website/docs/guide/binance-credenciais.md
@@ -34,6 +34,13 @@ Este guia reúne recomendações de segurança, configuração e uso das funcion
 - **Simulações e forecasting**: utilizam dados da Binance para projetar crescimento de portfólio e prever fechamentos, salvando históricos em `reports/`.
 - **Alertas enriquecidos**: variáveis de ambiente e configurações personalizadas refletem imediatamente nas mensagens enviadas.
 
+## Visualizando saldos com `/binance`
+
+- Respostas sempre ephemerais: os detalhes da conta aparecem apenas para o solicitante, reduzindo o risco de exposição de patrimônio.
+- Chaves somente leitura são suficientes para o resumo; o bot ignora seções para as quais a API retorna erro de permissão e exibe uma mensagem explicando a indisponibilidade.
+- Desative rapidamente com `ENABLE_BINANCE_COMMAND=false` ou `enableBinanceCommand: false` caso esteja rodando o bot em servidores compartilhados.
+- As seções (ativos configurados, saldos spot, conta/ativos de margem e posições) ficam disponíveis separadamente, permitindo validar quais permissões precisam ser reativadas sem inspecionar logs sensíveis.
+
 ## Checklist de segurança
 
 - [ ] IP allowlist configurada para as chaves com permissão de trade.

--- a/website/docs/guide/releases.md
+++ b/website/docs/guide/releases.md
@@ -1,0 +1,29 @@
+# Release Notes
+
+Os marcos abaixo consolidam funcionalidades entregues, a cobertura de testes que garante regressões e links úteis para auditória rápida do projeto.
+
+## vNext
+
+### Funcionalidades principais
+
+- `/binance` fornece um panorama seguro da conta Binance: respostas ephemerais, uso recomendado de chaves somente leitura e degradação suave caso endpoints de margem estejam bloqueados.
+- Ajustes de lucro mínimo (`/settings profit`) continuam sincronizados com alertas que aplicam o threshold antes de recomendar entradas.
+- Alertas agregados mantêm orientação explícita de buy/sell/hold e ordenação previsível por ativo ou rank de market cap.
+- Gráficos e projeções de forecasting seguem disponíveis para validar tendências e comparar o alvo previsto com o histórico recente.
+
+### Cobertura de testes de regressão
+
+| Funcionalidade | Suíte | Garantia fornecida |
+| --- | --- | --- |
+| Resumo Binance e degradação por permissão | `tests/trading/binance.test.js` e `tests/discordBot.test.js` | Valida autenticação, normalização numérica, respostas ephemerais e tolerância a falhas parciais das APIs.
+| Thresholds de lucro configuráveis | `tests/minimumProfit.test.js` e `tests/alerts/tradeLevelsAlert.test.js` | Confirma que limites globais/pessoais são persistidos e avaliados antes de destacar oportunidades.
+| Ordenação e orientação dos alertas | `tests/alerts/dispatcher.test.js` e `tests/alerts/messageBuilder.test.js` | Garante ordenação por ativo/rank e mensagens com guidance buy/sell/hold, variações e previsões.
+| Gráficos e forecasting | `tests/chart.test.js` | Cobra candlesticks, forecasts e gráficos de crescimento com métricas de confiança e drawdown.
+
+### Documentação e descoberta
+
+- README atualizado com recomendações de segurança, fluxo do comando `/binance` e link direto para estas notas.
+- Guia "Credenciais e integrações Binance" ampliado com detalhes do fluxo ephemereal e como lidar com permissões faltantes.
+- Página inicial do site destaca as notas de versão e o comportamento seguro do comando `/binance`.
+
+> Consulte as seções anteriores deste documento a cada entrega: mantenha a lista de funcionalidades alinhada ao que está publicado e referencie novas suítes de testes sempre que uma feature ganhar cobertura.

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -20,12 +20,13 @@ description: Visão geral do Crypto Daily Discord Bot com destaques das funciona
 
 ## Novidades recentes
 
-- **Comando `/binance`** consolidando saldos spot/margin e posições com base nas credenciais fornecidas.
+- **Comando `/binance`** com respostas ephemerais, modo somente leitura e degradação suave caso alguma permissão da Binance esteja indisponível.
 - **Thresholds de lucro configuráveis** por usuário ou globalmente via `/settings profit`.
 - **Alertas com orientação de buy/sell/hold** e métricas por timeframe.
 - **Simulador 100€ → 10M€** com relatórios armazenados em `reports/portfolio/`.
 - **Módulo de forecasting** que persiste previsões e gráficos comparativos de tendência.
 - **Testes de qualidade automatizados** validando estilo, semicolons e limpeza de diretórios gerados.
+- **Notas de versão dedicadas** documentando funcionalidades concluídas, cobertura de testes e links úteis de auditoria.
 
 ## Como começar
 


### PR DESCRIPTION
## Summary
- allow `getAccountOverview` to degrade gracefully per section, logging partial failures and keeping `/binance` replies ephemeral and informative
- add targeted regression tests for Binance overview fallbacks and minimum profit thresholds, alongside documentation updates covering the new `/binance` flow
- publish release notes and navigation entries that highlight wishlist features, their test coverage, and how contributors discover them

## Testing
- npm run lint
- npm test
- npm run test:coverage

------
https://chatgpt.com/codex/tasks/task_e_68d51839359c83269576d086919f498d