### PR TITLE
Document Binance command configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,8 +106,12 @@ NEWS_API_KEY=your-newsapi-key
 # SERPAPI_API_KEY: chave de acesso ao SerpAPI
 SERPAPI_API_KEY=your-serpapi-key
 
+## Comando Binance no Discord
+# ENABLE_BINANCE_COMMAND: habilita ou desabilita o comando /binance (padrão: true em config/default.json)
+ENABLE_BINANCE_COMMAND=true
+
 ## Binance Trading API
-# BINANCE_API_KEY: chave da API de trading da Binance
+# BINANCE_API_KEY: chave da Binance com leitura Spot/Margin e permissão "Enable Futures" para ver saldo USD-M
 BINANCE_API_KEY=your-binance-api-key
-# BINANCE_SECRET: segredo da API de trading da Binance
+# BINANCE_SECRET: segredo correspondente para assinar as chamadas privadas da Binance
 BINANCE_SECRET=your-binance-secret

--- a/README.md
+++ b/README.md
@@ -77,11 +77,14 @@ npm install
 
 ## Fluxo do comando `/binance`
 
-- Defina `enableBinanceCommand` em `config/default.json` (ou `ENABLE_BINANCE_COMMAND=false` no ambiente) caso queira desligar o resumo financeiro em servidores públicos.
-- O comando só responde quando `BINANCE_API_KEY` e `BINANCE_SECRET` estão configurados; utilize chaves somente leitura sempre que não precisar executar ordens.
+1. **Ative o recurso conscientemente**: por padrão `enableBinanceCommand` vem como `true` no `config/default.json`. Desative-o com `ENABLE_BINANCE_COMMAND=false` ou `enableBinanceCommand: false` sempre que operar em servidores compartilhados.
+2. **Forneça credenciais com escopo suficiente**: o resumo precisa de `BINANCE_API_KEY` e `BINANCE_SECRET` válidos com leitura de Spot/Margin. Ative também o flag "Enable Futures" na chave para liberar o saldo USD-M (o bot apenas lê os dados).
+3. **Valide antes do deploy**: execute `npm exec config-cli secrets check` para garantir que as variáveis estejam presentes e reinicie o bot para aplicar as mudanças de ambiente/configuração.
+
 - As respostas são sempre **ephemerais** para evitar vazamentos de patrimônio nos canais do Discord.
-- Quando alguma permissão (ex.: margem) estiver desabilitada, o bot degrada o resultado e explica quais seções ficaram indisponíveis em vez de falhar por completo.
+- Quando alguma permissão (ex.: margem ou futures) estiver desabilitada, o bot degrada o resultado e explica quais seções ficaram indisponíveis em vez de falhar por completo.
 - Logs com contexto `accountOverview` registram falhas nas seções individuais para facilitar auditorias sem expor dados sensíveis.
+- Ajuste o `binanceCacheTTL` se precisar reduzir chamadas ao endpoint; valores baixos (padrão 10 segundos) deixam o `/binance` mais responsivo durante testes interativos.
 
 ## Execução
 

--- a/WISHLIST.md
+++ b/WISHLIST.md
@@ -1,6 +1,6 @@
 # Wish List
 
-[] on discord user can see binance account (assets, positions, etc)
+[x] on discord user can see binance account (assets, positions, etc) — comando `/binance` entrega saldos spot/margin/futuros com logs estruturados e respostas ephemerais.
 [x] on discord user can set minimum profit value
 [x] on "alerts" you should consider the variation for each timeframe
 [x] on "alerts" you should sort by asset

--- a/website/docs/guide/binance-credenciais.md
+++ b/website/docs/guide/binance-credenciais.md
@@ -17,7 +17,7 @@ Este guia reúne recomendações de segurança, configuração e uso das funcion
 
 ## Configurando o bot
 
-1. Atualize o arquivo `.env` com as credenciais desejadas.
+1. Atualize o arquivo `.env` com as credenciais desejadas (`BINANCE_API_KEY`, `BINANCE_SECRET`) e, se quiser desligar o recurso, defina `ENABLE_BINANCE_COMMAND=false`.
 2. Ajuste `config/default.json` ou `config/custom.json` para definir:
    - `enableBinanceCommand` — liga/desliga o comando `/binance` (pode ser sobrescrito com `ENABLE_BINANCE_COMMAND=false`).
    - `trading.executor.enabled` — liga/desliga ordens reais.
@@ -25,6 +25,7 @@ Este guia reúne recomendações de segurança, configuração e uso das funcion
    - `trading.risk.maxDrawdownPercent` e `portfolio.growth.maxDrawdownPercent` — proteções contra quedas.
    - `alerts.thresholds.minimumProfitPercent` — alinhado aos novos comandos `/settings profit`.
 3. Reinicie o bot para que as mudanças de ambiente e config sejam aplicadas.
+4. Execute `npm exec config-cli secrets check` para validar se as variáveis obrigatórias estão presentes antes do deploy.
 
 ## Funcionalidades disponíveis
 
@@ -37,9 +38,16 @@ Este guia reúne recomendações de segurança, configuração e uso das funcion
 ## Visualizando saldos com `/binance`
 
 - Respostas sempre ephemerais: os detalhes da conta aparecem apenas para o solicitante, reduzindo o risco de exposição de patrimônio.
-- Chaves somente leitura são suficientes para o resumo; o bot ignora seções para as quais a API retorna erro de permissão e exibe uma mensagem explicando a indisponibilidade.
+- Chaves somente leitura são suficientes para o resumo. Se quiser ver saldo USD-M, habilite também o flag "Enable Futures" na chave. O bot ignora seções para as quais a API retorna erro de permissão e exibe uma mensagem explicando a indisponibilidade.
 - Desative rapidamente com `ENABLE_BINANCE_COMMAND=false` ou `enableBinanceCommand: false` caso esteja rodando o bot em servidores compartilhados.
 - As seções (ativos configurados, saldos spot, conta/ativos de margem e posições) ficam disponíveis separadamente, permitindo validar quais permissões precisam ser reativadas sem inspecionar logs sensíveis.
+
+### Checklist do `/binance`
+
+- [ ] `ENABLE_BINANCE_COMMAND` ajustado conforme a política do servidor.
+- [ ] Chave Binance com leitura Spot/Margin e flag "Enable Futures" quando quiser exibir saldo USD-M.
+- [ ] `BINANCE_API_KEY`/`BINANCE_SECRET` configurados e validados com `config-cli secrets check`.
+- [ ] Logs com contexto `accountOverview` revisados após o primeiro uso para confirmar que seções opcionais (margin/futures) estão respondendo.
 
 ## Checklist de segurança
 


### PR DESCRIPTION
## Summary
- document how to toggle the /binance command via ENABLE_BINANCE_COMMAND and describe required Binance API scopes
- expand the README and hosted docs with deployment guidance for the Binance account overview flow, including futures visibility and cache tips
- mark the wishlist item for the Discord Binance account view as complete with a short capability note

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d52c4425d88326a716cc0344333d0d