### PR TITLE
Add configurable analysis cron schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ npm install
 - Credenciais sensíveis continuam exclusivamente no `.env`. Combine `npm exec config-cli secrets check` com ferramentas de CI/CD para validar se as variáveis obrigatórias foram definidas antes do deploy.
 - Em ambientes temporários, exporte variáveis em linha (`ENABLE_BINANCE_COMMAND=false npm run once`) sem alterar arquivos locais.
 
+### Frequência das análises automáticas (`analysisFrequency`)
+
+- Controle o agendamento do pipeline principal (`runAll`) via `analysisFrequency` em `config/default.json` ou por `ANALYSIS_FREQUENCY` no ambiente.
+- Valores aceites: `15m`, `30m`, `hourly`, `2h`, `4h`, `6h`, `12h` e `daily`. Aliases como `1h`, `60m`, `24h` e `1d` são normalizados para os equivalentes mais próximos.
+- Quando um valor inválido for fornecido, o bot regista um aviso nos logs e faz fallback para o modo horário (`hourly`).
+
 ## Boas práticas para credenciais da Binance
 
 - Gere chaves **apenas com permissões necessárias**: leitura para alertas e dashboards; ativar "Enable Spot & Margin Trading" somente quando o executor automático for utilizado.


### PR DESCRIPTION
## Summary
- add a normalized analysis frequency helper that schedules runAll with audit logs and fallback handling
- document the supported `analysisFrequency` values and fallback behaviour in the README
- cover the new cron registration with a Vitest suite that mocks node-cron and validates once-mode behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de43d7bd108326b780fe4677c03360