### PR TITLE
Add general guidance summary with position sizing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 ## Discord
 # DISCORD_WEBHOOK_URL: Webhook para mensagens gerais
 DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/XXX/YYY
+# DISCORD_WEBHOOK_GENERAL: Webhook dedicado ao resumo com recomendações
+DISCORD_WEBHOOK_GENERAL=https://discord.com/api/webhooks/XXX/YYY
 # DISCORD_WEBHOOK_ALERTS_URL: Webhook para alertas
 DISCORD_WEBHOOK_ALERTS_URL=https://discord.com/api/webhooks/XXX/YYY
 # DISCORD_WEBHOOK_REPORTS_URL: Webhook para relatórios

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ npm install
    - `MAX_CONCURRENCY` limita quantas análises paralelas podem ocorrer (defina `1` para execução sequencial).
    - `BINANCE_CACHE_TTL_MINUTES` controla a validade do cache de preços compartilhado.
    - Variáveis `INDICATOR_*` permitem sobrescrever períodos de médias, configurações do MACD, multiplicadores de bandas de Bollinger/Keltner, etc.
-4. Revise os IDs dos canais/servidores onde os conteúdos serão publicados (`DISCORD_GUILD_ID`, `DISCORD_CHANNEL_CHARTS_ID`, `DISCORD_WEBHOOK_ALERTS`, ...).
+4. Revise os IDs dos canais/servidores onde os conteúdos serão publicados (`DISCORD_GUILD_ID`, `DISCORD_CHANNEL_CHARTS_ID`, `DISCORD_WEBHOOK_GENERAL`, `DISCORD_WEBHOOK_ALERTS`, ...).
 
 > 📌 Consulte `.env.example` para descrições completas e exemplos de cada variável disponível.
 
@@ -178,6 +178,16 @@ A pasta `src/alerts/` centraliza os módulos responsáveis por disparar notifica
 - **Heurísticas compostas**: `heuristicAlert` combina múltiplos sinais para priorizar eventos relevantes.
 
 Todos os módulos utilizam `alertCache` para evitar duplicidade e respeitam configurações de intensidade, canais e horários definidas em `config/*.json`.
+
+### Resumo diário com recomendações
+
+Além da listagem de alertas, o bot publica um resumo consolidado por ativo exibindo:
+
+- A decisão `buy/sell/hold` mais recente calculada pelo avaliador de postura, mesmo na ausência de novos alertas.
+- A recomendação textual (`guidance`) e a variação percentual por timeframe.
+- Um tamanho de posição estimado a partir de `CFG.accountEquity` combinado com `CFG.riskPerTrade`, ajudando a dimensionar a exposição.
+
+Configure o canal dedicado definindo `webhookGeneral` em `config/custom.json` ou exportando `DISCORD_WEBHOOK_GENERAL`. Caso nenhum webhook geral esteja disponível, o bot tenta usar `CFG.webhook` como fallback e registra um aviso quando também não estiver definido.
 
 ## Monitoramento e relatórios
 

--- a/config/default.json
+++ b/config/default.json
@@ -1,5 +1,6 @@
 {
   "webhook": null,
+  "webhookGeneral": null,
   "webhookAlerts": null,
   "webhookReports": null,
   "webhookDaily": null,

--- a/src/config.js
+++ b/src/config.js
@@ -868,6 +868,7 @@ function rebuildConfig({ reloadFromDisk = true, emitLog = false } = {}) {
     const nextCFG = clone(mergedConfig);
 
     nextCFG.webhook = process.env.DISCORD_WEBHOOK_URL ?? nextCFG.webhook ?? null;
+    nextCFG.webhookGeneral = process.env.DISCORD_WEBHOOK_GENERAL ?? nextCFG.webhookGeneral ?? null;
     nextCFG.webhookAlerts = process.env.DISCORD_WEBHOOK_ALERTS_URL ?? nextCFG.webhookAlerts ?? null;
     nextCFG.webhookReports = process.env.DISCORD_WEBHOOK_REPORTS_URL ?? nextCFG.webhookReports ?? null;
     nextCFG.webhookDaily = process.env.DISCORD_WEBHOOK_DAILY ?? nextCFG.webhookDaily ?? null;

--- a/website/docs/guide/introducao.md
+++ b/website/docs/guide/introducao.md
@@ -29,6 +29,7 @@ O projeto é dividido em módulos que coletam dados de exchanges, calculam indic
    cp .env.example .env
    ```
 3. Atualize tokens, webhooks e parâmetros extras conforme necessidade.
+4. Defina `DISCORD_WEBHOOK_GENERAL` (ou `webhookGeneral` via `config-cli`) para direcionar o resumo com recomendações de posição.
 
 ## Executando localmente
 
@@ -90,6 +91,12 @@ Cada bloco de alertas agora inclui uma linha explícita de decisão (`Decisão: 
 - **Hold (🟡)** se o cenário estiver neutro ou com convicção insuficiente.
 
 Além do rótulo, a linha de decisão mostra a postura dominante (alta, baixa ou neutra), o nível de confiança e os principais motivos calculados pelo motor de postura. Isso facilita validar rapidamente o racional por trás de cada alerta sem abrir relatórios adicionais.
+
+## Resumo geral com recomendações de posição
+
+A cada execução o bot também gera uma mensagem consolidada por ativo listando guidance, decisão atual e variação percentual de cada timeframe acompanhado de um tamanho de posição sugerido. O cálculo usa `CFG.accountEquity` multiplicado por `CFG.riskPerTrade` para estimar o capital exposto e aparece mesmo quando nenhum alerta específico é disparado, ajudando times de investimento a manter disciplina de sizing.
+
+> 💡 Configure `webhookGeneral` ou `DISCORD_WEBHOOK_GENERAL` para enviar esse resumo a um canal dedicado; quando nenhum webhook geral estiver definido, o bot tenta usar `CFG.webhook` e registra um aviso caso ambos estejam vazios.
 
 ## Alertas organizados por ativo
 

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -27,6 +27,7 @@ description: Visão geral do Crypto Daily Discord Bot com destaques das funciona
 - **Módulo de forecasting** que persiste previsões e gráficos comparativos de tendência.
 - **Testes de qualidade automatizados** validando estilo, semicolons e limpeza de diretórios gerados.
 - **Notas de versão dedicadas** documentando funcionalidades concluídas, cobertura de testes e links úteis de auditoria.
+- **Resumo geral com sizing sugerido** alinhando guidance, variação por timeframe e exposição recomendada por ativo.
 
 ## Como começar
 


### PR DESCRIPTION
## Summary
- add a guidance message builder that formats recommendations, variation context, and position sizing derived from account equity
- enqueue the new guidance summary after asset analysis using the general webhook with asset/timeframe deduplication safeguards
- document the general webhook configuration and investment summary across the README, docs site, and .env example while expanding unit coverage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de45e54790832688f28679b6b96db8