### PR TITLE
Log portfolio growth trades and attach Discord trade journal

### DIFF
--- a/src/portfolio/growthSummary.js
+++ b/src/portfolio/growthSummary.js
@@ -107,6 +107,161 @@ const formatReportsLine = ({ summary, includeReportLinks, locale }) => {
     return `- Relatórios salvos (${progressPct} da meta): ${reportPaths.map(entry => `\`${entry}\``).join(", ")}`;
 };
 
+const MAX_DIGEST_ASSETS = 5;
+const MAX_TRADES_PER_ATTACHMENT = 1000;
+
+const buildTradeAggregates = (trades) => {
+    const aggregates = new Map();
+    for (const trade of trades) {
+        const asset = typeof trade?.asset === "string" ? trade.asset.toUpperCase() : null;
+        const action = typeof trade?.action === "string" ? trade.action.toUpperCase() : null;
+        const quantity = Number(trade?.quantity);
+        const price = Number(trade?.price);
+        const notional = Number.isFinite(quantity) && Number.isFinite(price) ? quantity * price : 0;
+        if (!asset || !Number.isFinite(quantity) || quantity <= 0 || !Number.isFinite(price) || price <= 0 || (action !== "BUY" && action !== "SELL")) {
+            continue;
+        }
+        const entry = aggregates.get(asset) ?? {
+            asset,
+            buyCount: 0,
+            buyQty: 0,
+            buyNotional: 0,
+            sellCount: 0,
+            sellQty: 0,
+            sellNotional: 0,
+        };
+        if (action === "BUY") {
+            entry.buyCount += 1;
+            entry.buyQty += quantity;
+            entry.buyNotional += notional;
+        } else {
+            entry.sellCount += 1;
+            entry.sellQty += quantity;
+            entry.sellNotional += notional;
+        }
+        aggregates.set(asset, entry);
+    }
+    return Array.from(aggregates.values()).map((entry) => ({
+        ...entry,
+        netQty: entry.buyQty - entry.sellQty,
+        netNotional: entry.buyNotional - entry.sellNotional,
+        totalNotional: entry.buyNotional + entry.sellNotional,
+    }));
+};
+
+const buildTradeDigest = ({ trades, locale }) => {
+    if (!Array.isArray(trades) || trades.length === 0) {
+        return null;
+    }
+    const aggregates = buildTradeAggregates(trades)
+        .sort((a, b) => b.totalNotional - a.totalNotional || b.buyCount + b.sellCount - (a.buyCount + a.sellCount));
+    if (aggregates.length === 0) {
+        return null;
+    }
+    const formatterQty = (value) => formatNumber(value, {
+        locale,
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 4,
+    });
+    const topAggregates = aggregates.slice(0, MAX_DIGEST_ASSETS);
+    const digestParts = topAggregates.map((entry) => {
+        const segments = [];
+        if (entry.buyCount > 0) {
+            segments.push(`B${entry.buyCount}=${formatterQty(entry.buyQty)}`);
+        }
+        if (entry.sellCount > 0) {
+            segments.push(`S${entry.sellCount}=${formatterQty(entry.sellQty)}`);
+        }
+        if (segments.length === 0) {
+            segments.push("sem trades");
+        }
+        const net = entry.netQty;
+        const netLabel = Number.isFinite(net) && net !== 0
+            ? `Δ ${net > 0 ? "+" : ""}${formatterQty(net)}`
+            : "Δ 0";
+        segments.push(netLabel);
+        return `${entry.asset}: ${segments.join(" · ")}`;
+    });
+    const remaining = aggregates.length - topAggregates.length;
+    if (remaining > 0) {
+        digestParts.push(`+${remaining} ativos`);
+    }
+    return digestParts.join(" | ");
+};
+
+const sanitizeRunId = (runAt) => {
+    const base = typeof runAt === "string" && runAt.trim() !== ""
+        ? runAt
+        : new Date().toISOString();
+    return base.replace(/[^a-z0-9]+/gi, "-").replace(/-+/g, "-");
+};
+
+const chunkTrades = (trades) => {
+    if (!Array.isArray(trades) || trades.length === 0) {
+        return [];
+    }
+    const chunks = [];
+    for (let idx = 0; idx < trades.length; idx += MAX_TRADES_PER_ATTACHMENT) {
+        chunks.push(trades.slice(idx, idx + MAX_TRADES_PER_ATTACHMENT));
+    }
+    return chunks;
+};
+
+const formatCsvLine = (trade) => {
+    const timestamp = typeof trade?.timestamp === "string" ? trade.timestamp : "";
+    const asset = typeof trade?.asset === "string" ? trade.asset.toUpperCase() : "";
+    const action = typeof trade?.action === "string" ? trade.action.toUpperCase() : "";
+    const quantity = Number(trade?.quantity);
+    const price = Number(trade?.price);
+    const value = Number(trade?.value);
+    const reason = typeof trade?.reason === "string" ? trade.reason : "";
+    const formatDecimal = (input, fractionDigits) => {
+        if (!Number.isFinite(input)) {
+            return "0";
+        }
+        return input.toFixed(fractionDigits);
+    };
+    return [
+        timestamp,
+        asset,
+        action,
+        formatDecimal(quantity, 8),
+        formatDecimal(price, 2),
+        formatDecimal(value, 2),
+        reason,
+    ].join(",");
+};
+
+const buildTradeAttachments = ({ trades, runAt }) => {
+    if (!Array.isArray(trades) || trades.length === 0) {
+        return [];
+    }
+    const chunks = chunkTrades(trades);
+    const runId = sanitizeRunId(runAt);
+    const attachments = [];
+    chunks.forEach((chunk, index) => {
+        const suffix = chunks.length > 1 ? `-${index + 1}` : "";
+        const csvLines = ["timestamp,asset,side,quantity,price,notional,reason", ...chunk.map(formatCsvLine)];
+        const csvContent = csvLines.join("\n");
+        const csvBuffer = Buffer.from(csvContent, "utf8");
+        attachments.push({
+            filename: `portfolio-trades-${runId}${suffix}.csv`,
+            contentType: "text/csv",
+            content: csvBuffer,
+            size: csvBuffer.length,
+        });
+        const jsonContent = JSON.stringify(chunk, null, 2);
+        const jsonBuffer = Buffer.from(jsonContent, "utf8");
+        attachments.push({
+            filename: `portfolio-trades-${runId}${suffix}.json`,
+            contentType: "application/json",
+            content: jsonBuffer,
+            size: jsonBuffer.length,
+        });
+    });
+    return attachments;
+};
+
 /**
  * Builds a Discord-friendly summary message describing the current state of the 100€ → 10M€ simulation.
  * @param {Object} params - Message builder parameters.
@@ -123,7 +278,7 @@ export function buildPortfolioGrowthDiscordMessage({
     includeReportLinks = true,
 } = {}) {
     if (!summary || typeof summary !== "object") {
-        return "";
+        return { message: "", attachments: [] };
     }
 
     const safeLocale = typeof locale === "string" && locale.trim() !== "" ? locale : DEFAULT_LOCALE;
@@ -173,12 +328,31 @@ export function buildPortfolioGrowthDiscordMessage({
         lines.push(`- Janela analisada: ${formatNumber(yearsElapsed, { locale: safeLocale, minimumFractionDigits: 1, maximumFractionDigits: 1 })} anos (${formatNumber(durationDays, { locale: safeLocale, minimumFractionDigits: 0, maximumFractionDigits: 0 })} dias)`);
     }
 
+    const trades = Array.isArray(summary.trades) ? summary.trades : [];
+    const tradeDigest = buildTradeDigest({ trades, locale: safeLocale });
+    if (tradeDigest) {
+        const tradeCount = formatNumber(trades.length, {
+            locale: safeLocale,
+            minimumFractionDigits: 0,
+            maximumFractionDigits: 0,
+        });
+        lines.push(`- Trades (${tradeCount} ordens): ${tradeDigest}`);
+    }
+
     const reportsLine = formatReportsLine({ summary, includeReportLinks, locale: safeLocale });
     if (reportsLine) {
         lines.push(reportsLine);
     }
 
-    return lines.join("\n");
+    const attachments = buildTradeAttachments({ trades, runAt: summary.runAt });
+    if (attachments.length > 0) {
+        lines.push(`- Diário de trades anexado (${attachments.length} arquivo${attachments.length > 1 ? "s" : ""}).`);
+    }
+
+    return {
+        message: lines.join("\n"),
+        attachments,
+    };
 }
 
 export const __testUtils = {
@@ -187,4 +361,6 @@ export const __testUtils = {
     formatNumber,
     formatDate,
     formatYears,
+    buildTradeDigest,
+    buildTradeAttachments,
 };

--- a/tests/portfolio/growth.test.js
+++ b/tests/portfolio/growth.test.js
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -117,6 +118,29 @@ describe("portfolio growth simulation", () => {
         expect(result?.progress?.pct).toBeGreaterThan(0);
         expect(result?.discord?.message).toContain("Simulação 100€ → 10M€");
         expect(result?.discordMessage).toBe(result?.discord?.message);
+        expect(Array.isArray(result?.trades)).toBe(true);
+        expect(result.trades.length).toBeGreaterThan(0);
+        const sampleTrade = result.trades[0];
+        expect(sampleTrade).toMatchObject({
+            asset: expect.any(String),
+            action: expect.any(String),
+            quantity: expect.any(Number),
+            price: expect.any(Number),
+            reason: expect.any(String),
+        });
+        expect(sampleTrade).toHaveProperty("timestamp");
+        expect(sampleTrade).toHaveProperty("value");
+        expect(Array.isArray(result.discord.attachments)).toBe(true);
+        expect(result.discord.attachments.length).toBeGreaterThan(0);
+        expect(result.discord.attachments[0].content).toBeInstanceOf(Buffer);
+        const persisted = JSON.parse(fs.readFileSync(result.reports.summaryPath, "utf8"));
+        expect(Array.isArray(persisted.trades)).toBe(true);
+        expect(persisted.discord.attachments[0]).toMatchObject({
+            filename: expect.any(String),
+            contentType: expect.any(String),
+            size: expect.any(Number),
+        });
+        expect(persisted.discord.attachments[0]).not.toHaveProperty("content");
     });
 
     it("retorna null quando o módulo está desativado", async () => {

--- a/tests/portfolio/growthSummary.test.js
+++ b/tests/portfolio/growthSummary.test.js
@@ -32,32 +32,65 @@ describe("buildPortfolioGrowthDiscordMessage", () => {
     };
 
     it("monta mensagem com métricas principais e links locais", () => {
-        const message = buildPortfolioGrowthDiscordMessage({
+        const payload = buildPortfolioGrowthDiscordMessage({
             summary: baseSummary,
             mention: "@here",
             locale: "pt-PT",
             includeReportLinks: true,
         });
 
-        expect(message).toContain("@here");
-        expect(message).toContain("Simulação 100€ → 10M€ · Balanced");
-        expect(message).toContain("Valor atual:");
-        expect(message).toContain("Meta:");
-        expect(message).toContain("Risco:");
-        expect(message).toContain("Relatórios salvos");
+        expect(payload.message).toContain("@here");
+        expect(payload.message).toContain("Simulação 100€ → 10M€ · Balanced");
+        expect(payload.message).toContain("Valor atual:");
+        expect(payload.message).toContain("Meta:");
+        expect(payload.message).toContain("Risco:");
+        expect(payload.message).toContain("Relatórios salvos");
+        expect(payload.attachments).toHaveLength(0);
     });
 
     it("omite relatórios quando includeReportLinks = false", () => {
-        const message = buildPortfolioGrowthDiscordMessage({
+        const payload = buildPortfolioGrowthDiscordMessage({
             summary: baseSummary,
             includeReportLinks: false,
         });
 
-        expect(message).not.toContain("Relatórios salvos");
+        expect(payload.message).not.toContain("Relatórios salvos");
     });
 
     it("retorna string vazia para resumo inválido", () => {
-        const message = buildPortfolioGrowthDiscordMessage({ summary: null });
-        expect(message).toBe("");
+        const payload = buildPortfolioGrowthDiscordMessage({ summary: null });
+        expect(payload).toEqual({ message: "", attachments: [] });
+    });
+
+    it("gera digest compacto e anexos quando há trades", () => {
+        const trades = Array.from({ length: 12 }, (_, idx) => ({
+            timestamp: new Date(2024, 0, idx + 1).toISOString(),
+            asset: idx % 2 === 0 ? "BTC" : "ETH",
+            action: idx % 3 === 0 ? "SELL" : "BUY",
+            quantity: 0.1 + (idx * 0.01),
+            price: 25_000 + (idx * 500),
+            value: (0.1 + (idx * 0.01)) * (25_000 + (idx * 500)),
+            reason: idx % 3 === 0 ? "rebalance" : "interval_rebalance",
+        }));
+
+        const payload = buildPortfolioGrowthDiscordMessage({
+            summary: { ...baseSummary, trades, runAt: "2024-01-31T00:00:00.000Z" },
+            locale: "pt-PT",
+        });
+
+        expect(payload.message).toContain("Trades (12 ordens)");
+        expect(payload.message).toMatch(/BTC:/);
+        expect(payload.message).toMatch(/ETH:/);
+        expect(payload.message).toContain("Diário de trades anexado");
+        expect(payload.attachments.length).toBeGreaterThan(0);
+        const csvAttachment = payload.attachments.find((attachment) => attachment.contentType === "text/csv");
+        expect(csvAttachment?.filename).toMatch(/portfolio-trades/);
+        const csvPreview = csvAttachment ? csvAttachment.content.toString("utf8").split("\n").slice(0, 3) : [];
+        expect(csvPreview[0]).toBe("timestamp,asset,side,quantity,price,notional,reason");
+        expect(csvPreview[1]).toMatch(/BTC/);
+        const jsonAttachment = payload.attachments.find((attachment) => attachment.contentType === "application/json");
+        expect(jsonAttachment).toBeTruthy();
+        const parsed = JSON.parse(jsonAttachment.content.toString("utf8"));
+        expect(parsed[0]).toHaveProperty("asset");
     });
 });

--- a/website/docs/guide/portfolio-growth.md
+++ b/website/docs/guide/portfolio-growth.md
@@ -105,7 +105,7 @@ Trecho relevante de `config/default.json`:
 
 Quando o módulo está ativo (`portfolioGrowth.enabled = true`):
 
-- `reports/growth/latest.json`: resumo completo do último ciclo com métricas e histórico detalhado.
+- `reports/growth/latest.json`: resumo completo do último ciclo com métricas, histórico detalhado e o diário de trades executados (`summary.trades`).
 - `reports/growth/progression.json`: série temporal preparada para dashboards externos.
 - `reports/growth/runs.json`: arquivo acumulativo com os resultados das últimas execuções.
 - `charts/growth/portfolio_growth_<timestamp>.png`: gráfico com valor do portfólio, capital investido, caixa e drawdown.
@@ -114,7 +114,7 @@ Se `reporting.appendToUploads` estiver habilitado, o gráfico também é publica
 
 ## Resumo automático no Discord
 
-Configure o bloco `portfolioGrowth.discord` para que o bot envie um texto conciso com o andamento rumo aos €10 milhões. O resumo inclui valor atual, CAGR, retorno acumulado, aportes realizados, progresso percentual da meta e indicadores de risco.
+Configure o bloco `portfolioGrowth.discord` para que o bot envie um texto conciso com o andamento rumo aos €10 milhões. O resumo inclui valor atual, CAGR, retorno acumulado, aportes realizados, progresso percentual da meta, indicadores de risco e um digest das operações mais recentes por ativo. O diário completo é anexado em CSV/JSON sempre que houver negociações no ciclo.
 
 ```text
 @here
@@ -123,7 +123,9 @@ Configure o bloco `portfolioGrowth.discord` para que o bot envie um texto concis
 - Capital investido: €1 200,00 (aportes €1 100,00 em 12 contribuições)
 - Meta: €10 000 000,00 · progresso 0,12% · falta €9 987 655,00 · projeção 8,4 anos
 - Risco: drawdown máx 32,00% · vol anual 54,00% · Sharpe 1,20
+- Trades (24 ordens): BTC: B12=0,3450 · S5=0,2100 · Δ +0,1350 | ETH: B6=2,1000 · Δ +2,1000
 - Janela analisada: 3,0 anos (1 095 dias)
+- Diário de trades anexado (4 arquivos).
 - Relatórios salvos (0,12% da meta): `reports/growth/latest.json`, `charts/growth/portfolio_growth_2024-02-01.png`
 ```
 


### PR DESCRIPTION
## Summary
- log every portfolio growth buy/sell (rebalance and risk controls) and persist the trade journal in the simulation summary
- enrich the Discord portfolio growth message with a per-asset trade digest plus CSV/JSON attachments while sanitising stored metadata
- document the new trade diary output and cover it with portfolio growth tests

## Testing
- npm run test -- portfolio

------
https://chatgpt.com/codex/tasks/task_e_68de7d7f9d6c83269a1495820d5356a0