### PR TITLE
Add /help slash command and centralize metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,13 +143,16 @@ Comandos comuns:
 
 | Comando | Argumentos | O que faz |
 |---------|------------|-----------|
+| `/help` | — | Lista todos os comandos disponíveis diretamente no Discord. |
 | `/chart ativo:<ticker> tf:<timeframe>` | `ativo` (lista de chaves suportadas), `tf` (timeframes como `15m`, `1h`, `4h`, `1d`, `45m`, etc.) | Renderiza um gráfico de candles com indicadores sobrepostos e devolve a imagem no canal/DM. |
 | `/watch add ativo:<ticker>` | — | Adiciona o ativo à watchlist pessoal do usuário. |
 | `/watch remove ativo:<ticker>` | — | Remove o ativo da watchlist pessoal. |
 | `/status` | — | Mostra uptime do bot e a watchlist do solicitante. |
 | `/analysis ativo:<ticker> tf:<timeframe>` | — | Executa a mesma análise automática usada nos alertas, retornando um resumo textual. |
 | `/settings risk percent value:<0-5>` | `value` (percentual) | Atualiza o risco por trade aplicado na estratégia automática. |
-| `/settings profit percent value:<0-20>` | `value` (percentual) | Define o lucro mínimo global ou pessoal antes que sinais de venda sejam destacados. |
+| `/settings profit view` | — | Mostra o lucro mínimo padrão, o pessoal (quando configurado) e o valor aplicado nas análises. |
+| `/settings profit default value:<0-100>` | `value` (percentual) | Define o lucro mínimo global aplicado aos relatórios e análises. |
+| `/settings profit personal value:<0-100>` | `value` (percentual) | Define o seu lucro mínimo pessoal aplicado às suas interações. |
 | `/binance` | — | Exibe saldo spot, métricas de margem e posições agregadas com base nas credenciais configuradas. |
 
 Todos os comandos são registrados automaticamente quando o bot inicia e exigem permissões de aplicação no servidor configurado.

--- a/tests/discordBot.test.js
+++ b/tests/discordBot.test.js
@@ -172,6 +172,29 @@ describe('discord bot interactions', () => {
     });
   });
 
+  it('lista comandos, subcomandos e argumentos no /help', async () => {
+    const { handleInteraction } = await loadBot();
+
+    const interaction = {
+      isChatInputCommand: () => true,
+      commandName: 'help',
+      reply: vi.fn(),
+    };
+
+    await handleInteraction(interaction);
+
+    expect(interaction.reply).toHaveBeenCalledWith({
+      content: expect.any(String),
+      ephemeral: true,
+    });
+
+    const message = interaction.reply.mock.calls[0][0].content;
+    expect(message).toContain('/chart — Exibe um gráfico de preços com indicadores técnicos.');
+    expect(message).toContain('Subcomando add — Adiciona um ativo à watchlist pessoal.');
+    expect(message).toContain('value (obrigatório) — Percentual de lucro mínimo global (0 a 100).');
+    expect(message).toContain('/help — Lista os comandos disponíveis e seus objetivos.');
+  });
+
   it('handles /binance command and formats overview', async () => {
     getAccountOverview.mockResolvedValue({
       assets: [


### PR DESCRIPTION
## Summary
- centralize Discord command metadata so registration and help share descriptions
- register a new /help command that replies with localized usage details
- update documentation and extend tests to cover the help response

## Testing
- npm run test -- tests/discordBot.test.js

------
https://chatgpt.com/codex/tasks/task_e_68de849c6ba88326a8923df087b1a2d5