### PR TITLE
Add five-minute analysis frequency support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ npm install
 ### Frequência das análises automáticas (`analysisFrequency`)
 
 - Controle o agendamento do pipeline principal (`runAll`) via `analysisFrequency` em `config/default.json` ou por `ANALYSIS_FREQUENCY` no ambiente.
-- Valores aceites: `15m`, `30m`, `hourly`, `2h`, `4h`, `6h`, `12h` e `daily`. Aliases como `1h`, `60m`, `24h` e `1d` são normalizados para os equivalentes mais próximos.
+- Valores aceites: `5m`, `15m`, `30m`, `hourly`, `2h`, `4h`, `6h`, `12h` e `daily`. Aliases como `5min`, `300s`, `1h`, `60m`, `24h` e `1d` são normalizados para os equivalentes mais próximos.
 - Quando um valor inválido for fornecido, o bot regista um aviso nos logs e faz fallback para o modo horário (`hourly`).
 
 ## Boas práticas para credenciais da Binance

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,7 @@ const ONCE = process.argv.includes("--once");
 
 const DEFAULT_ANALYSIS_FREQUENCY_KEY = "hourly";
 const ANALYSIS_FREQUENCY_SCHEDULES = new Map([
+    ["5m", { cron: "*/5 * * * *", label: "every 5 minutes" }],
     ["15m", { cron: "*/15 * * * *", label: "every 15 minutes" }],
     ["30m", { cron: "*/30 * * * *", label: "every 30 minutes" }],
     ["hourly", { cron: "0 * * * *", label: "hourly at minute 0" }],
@@ -53,6 +54,8 @@ const ANALYSIS_FREQUENCY_SCHEDULES = new Map([
     ["daily", { cron: "0 0 * * *", label: "daily at midnight" }],
 ]);
 const ANALYSIS_FREQUENCY_ALIASES = new Map([
+    ["5min", "5m"],
+    ["300s", "5m"],
     ["1h", "hourly"],
     ["60m", "hourly"],
     ["120m", "2h"],

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -257,11 +257,11 @@ describe("analysis scheduler", () => {
     });
 
     it("schedules runAll according to analysisFrequency", async () => {
-        cfgMock.analysisFrequency = "15m";
+        cfgMock.analysisFrequency = "5m";
 
         await import("../src/index.js");
 
-        const analysisTask = scheduledTasks.find((task) => task.expression === "*/15 * * * *");
+        const analysisTask = scheduledTasks.find((task) => task.expression === "*/5 * * * *");
         expect(analysisTask).toBeDefined();
         expect(analysisTask?.options).toEqual(expect.objectContaining({ timezone: cfgMock.tz }));
 


### PR DESCRIPTION
## Summary
- add a five-minute analysis cadence with the appropriate cron schedule and alias normalization
- update the operator documentation to mention the new cadence

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0074f538c8326a0093d32c28cb816