### PR TITLE
Document Google Sheets exporter setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -114,14 +114,19 @@ ENABLE_BINANCE_COMMAND=true
 
 ## Exportação para Google Sheets
 # GOOGLE_SHEETS_ENABLED: ativa o exportador de mensagens para planilhas
+#   Combine com `npm exec config-cli set googleSheets.enabled true` para refletir no config runtime.
 GOOGLE_SHEETS_ENABLED=false
 # GOOGLE_SHEETS_SPREADSHEET_ID: ID da planilha (https://docs.google.com/spreadsheets/d/<ID>/edit)
+#   Copie o trecho destacado entre `/d/` e `/edit` após criar a planilha compartilhada com a conta de serviço.
 GOOGLE_SHEETS_SPREADSHEET_ID=
 # GOOGLE_SHEETS_CREDENTIALS_FILE: caminho do arquivo JSON de credenciais da conta de serviço
+#   Gere a chave em Google Cloud Console > IAM & Admin > Service Accounts, faça download e referencie o caminho relativo.
 GOOGLE_SHEETS_CREDENTIALS_FILE=service-account.json
 # GOOGLE_SHEETS_CREDENTIALS_JSON: credenciais inline em formato JSON (alternativa a GOOGLE_SHEETS_CREDENTIALS_FILE)
+#   Cole o conteúdo da chave JSON aqui quando não puder salvar arquivo no filesystem do deploy.
 GOOGLE_SHEETS_CREDENTIALS_JSON=
 # GOOGLE_SHEETS_CHANNEL_MAP: mapeamento canal → aba (JSON ou pares separados por vírgula, ex.: 1234567890=BTC,0987654321=ETH)
+#   Use os IDs de canal do Discord como chave e o nome da aba da planilha como valor para segmentar os dados.
 GOOGLE_SHEETS_CHANNEL_MAP={"1234567890":"BTC","0987654321":"ETH"}
 
 ## Binance Trading API

--- a/README.md
+++ b/README.md
@@ -55,7 +55,12 @@ npm install
    - `BINANCE_CACHE_TTL_MINUTES` controla a validade do cache de preços compartilhado.
    - Variáveis `INDICATOR_*` permitem sobrescrever períodos de médias, configurações do MACD, multiplicadores de bandas de Bollinger/Keltner, etc.
 4. Revise os IDs dos canais/servidores onde os conteúdos serão publicados (`DISCORD_GUILD_ID`, `DISCORD_CHANNEL_CHARTS_ID`, `DISCORD_WEBHOOK_GENERAL`, `DISCORD_WEBHOOK_ALERTS`, ...).
-5. Para exportar mensagens para planilhas, defina `GOOGLE_SHEETS_ENABLED=true`, informe `GOOGLE_SHEETS_SPREADSHEET_ID` e forneça credenciais via `GOOGLE_SHEETS_CREDENTIALS_FILE` ou `GOOGLE_SHEETS_CREDENTIALS_JSON`. Use `GOOGLE_SHEETS_CHANNEL_MAP` para relacionar canais do Discord às abas da planilha.
+5. Para exportar mensagens para planilhas:
+   - Ative o recurso definindo `GOOGLE_SHEETS_ENABLED=true` no `.env` **e** habilitando `googleSheets.enabled` via `npm exec config-cli set googleSheets.enabled true` (o valor do arquivo de configuração vence quando ambos estiverem definidos).
+   - Crie uma conta de serviço no [Google Cloud Console](https://console.cloud.google.com/): gere uma chave JSON, compartilhe a planilha com o e-mail da conta e aponte o caminho do arquivo com `GOOGLE_SHEETS_CREDENTIALS_FILE` **ou** cole o JSON no `GOOGLE_SHEETS_CREDENTIALS_JSON`.
+   - Obtenha o ID da planilha diretamente da URL (`https://docs.google.com/spreadsheets/d/<ID>/edit`) e informe em `GOOGLE_SHEETS_SPREADSHEET_ID`.
+   - Mapeie os canais/relatórios para abas específicas usando `GOOGLE_SHEETS_CHANNEL_MAP` (por exemplo, `{ "1234567890": "alerts-general", "987654321": "portfolio-growth" }`). Webhooks reutilizam a aba mesmo quando mudam o nome exibido.
+   - Consulte as [notas de design do exportador](docs/google-sheets-export.md) para detalhes de layout, colunas obrigatórias e regras de normalização.
 
 > 📌 Consulte `.env.example` para descrições completas e exemplos de cada variável disponível.
 


### PR DESCRIPTION
## Summary
- document the steps to enable the Google Sheets exporter, configure the service account, and link to the design notes
- clarify the environment variable examples for Google Sheets credentials and channel-to-worksheet mapping

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e3e2c565fc83268ec1b0743d8e8830