### PR TITLE
Add RAG configuration and Postgres vector store scaffolding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,24 @@ INDICATOR_CCI_PERIOD=20
 # OPENROUTER_API_KEY: chave de acesso ao OpenRouter
 OPENROUTER_API_KEY=your-openrouter-key
 
+## Recuperação aumentada por geração (RAG)
+# RAG_PG_URL: URL de conexão com Postgres/pgvector
+RAG_PG_URL=postgres://user:password@localhost:5432/crypto_bot
+# RAG_EMBEDDING_MODEL: modelo utilizado para gerar embeddings dos chunks
+RAG_EMBEDDING_MODEL=text-embedding-3-large
+# RAG_CHUNK_SIZE: tamanho máximo de caracteres por chunk antes da vetorização
+RAG_CHUNK_SIZE=800
+# RAG_CHUNK_OVERLAP: quantidade de caracteres sobrepostos entre chunks consecutivos
+RAG_CHUNK_OVERLAP=160
+# RAG_INGEST_CRON: agendamento (cron) do job de ingestão vetorial
+RAG_INGEST_CRON=0 * * * *
+# RAG_SEARCH_LIMIT: máximo de chunks retornados por busca vetorial
+RAG_SEARCH_LIMIT=5
+# RAG_ACTIVE_MODEL: modelo atual usado para responder às consultas RAG
+RAG_ACTIVE_MODEL=openrouter/gpt-4o-mini
+# RAG_CANDIDATE_MODEL: modelo candidato para experimentos e comparação
+RAG_CANDIDATE_MODEL=
+
 ## News API
 # NEWS_API_KEY: chave de acesso ao NewsAPI
 NEWS_API_KEY=your-newsapi-key

--- a/README.md
+++ b/README.md
@@ -249,6 +249,20 @@ Para manter os canais organizados, configure webhooks específicos para cada tip
 - `webhookDaily` permanece reservado para o resumo diário (`assetKey === 'DAILY'`) quando não há canais de análise configurados.
 - `webhookMonthly` direciona o relatório mensal com gráficos anexados.
 
+## Recuperação aumentada por geração (RAG)
+
+O bloco `rag` de `config/default.json` organiza as integrações de busca vetorial utilizadas pelos agentes de IA:
+
+- `pgUrl` define a URL de conexão com o Postgres que possui a extensão `pgvector` habilitada.
+- `embeddingModel` indica o modelo responsável por gerar os vetores (`RAG_EMBEDDING_MODEL`).
+- `chunkSize` e `chunkOverlap` controlam o fracionamento dos textos antes da vetorização, via utilitário compatível com ESM (`@langchain/textsplitters`).
+- `ingestCron` agenda a rotina de ingestão automática; sobrescreva com `RAG_INGEST_CRON` para ajustar a cadência.
+- `searchLimit` limita a quantidade de chunks retornados em buscas (`RAG_SEARCH_LIMIT`).
+- `activeModel` registra o modelo atual usado para responder consultas (`RAG_ACTIVE_MODEL`).
+- `candidateModel` guarda o modelo em avaliação para experimentos A/B (`RAG_CANDIDATE_MODEL`).
+
+As mesmas chaves podem ser definidas por variáveis de ambiente `RAG_*`, que prevalecem sobre `config/custom.json` em tempo de execução.
+
 ## Monitoramento e relatórios
 
 - As entradas de deduplicação de alertas são expurgadas diariamente e também no start do processo, mantendo o cache coerente entre execuções longas e jobs efêmeros.

--- a/config/default.json
+++ b/config/default.json
@@ -41,6 +41,16 @@
   "analysisFrequency": "hourly",
   "openrouterApiKey": null,
   "openrouterModel": "openrouter/sonoma-dusk-alpha",
+  "rag": {
+    "pgUrl": null,
+    "embeddingModel": "text-embedding-3-large",
+    "chunkSize": 800,
+    "chunkOverlap": 160,
+    "ingestCron": "0 * * * *",
+    "searchLimit": 5,
+    "activeModel": null,
+    "candidateModel": null
+  },
   "enableCharts": true,
   "enableAlerts": true,
   "enableAnalysis": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@jvddavid/pino-rotating-file": "^1.0.7",
+        "@langchain/textsplitters": "^0.1.0",
         "@tensorflow/tfjs": "^4.22.0",
         "@vitalets/google-translate-api": "^9.2.1",
         "axios": "^1.12.2",
@@ -24,10 +25,13 @@
         "luxon": "^3.7.2",
         "node-cron": "^3.0.3",
         "openai": "^5.23.0",
+        "pg": "^8.12.0",
+        "pgvector": "^0.2.0",
         "pino": "^8.21.0",
         "prom-client": "^15.1.3",
         "puppeteer": "^24.22.2",
         "rss-parser": "^3.13.0",
+        "uuid": "^11.0.3",
         "ws": "^8.18.3"
       },
       "bin": {
@@ -388,6 +392,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@discordjs/builders": {
       "version": "1.11.3",
@@ -1503,6 +1514,72 @@
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
       "license": "MIT"
     },
+    "node_modules/@langchain/core": {
+      "version": "0.3.78",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.78.tgz",
+      "integrity": "sha512-Nn0x9erQlK3zgtRU1Z8NUjLuyW0gzdclMsvLQ6wwLeDqV91pE+YKl6uQb+L2NUDs4F0N7c2Zncgz46HxrvPzuA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@cfworker/json-schema": "^4.0.2",
+        "ansi-styles": "^5.0.0",
+        "camelcase": "6",
+        "decamelize": "1.2.0",
+        "js-tiktoken": "^1.0.12",
+        "langsmith": "^0.3.67",
+        "mustache": "^4.2.0",
+        "p-queue": "^6.6.2",
+        "p-retry": "4",
+        "uuid": "^10.0.0",
+        "zod": "^3.25.32",
+        "zod-to-json-schema": "^3.22.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@langchain/core/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@langchain/textsplitters": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@langchain/textsplitters/-/textsplitters-0.1.0.tgz",
+      "integrity": "sha512-djI4uw9rlkAb5iMhtLED+xJebDdAG935AdP4eRTB02R7OB/act55Bj9wsskhZsvuyQRpO4O1wQOp85s6T6GWmw==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tiktoken": "^1.0.12"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.2.21 <0.4.0"
+      }
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
@@ -2262,6 +2339,13 @@
       "integrity": "sha512-esIJx9bQg+QYF0ra8GnvfianIY8qWB0GBx54PK5Eps6m+xTj86KLavHv6qDhzKcu5UUOgNfJ2pWaIIV7TRUd9Q==",
       "license": "MIT"
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/seedrandom": {
       "version": "2.4.34",
       "resolved": "https://registry.npmjs.org/@types/seedrandom/-/seedrandom-2.4.34.tgz",
@@ -2274,6 +2358,13 @@
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/web-bluetooth": {
       "version": "0.0.21",
@@ -3254,6 +3345,19 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/canvas": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/canvas/-/canvas-3.2.0.tgz",
@@ -3529,6 +3633,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/console-table-printer": {
+      "version": "2.14.6",
+      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.14.6.tgz",
+      "integrity": "sha512-MCBl5HNVaFuuHW6FGbL/4fB7N/ormCy+tQ+sxTrF6QtSbSNETvPuOVbkJBhzDgYhvjWGrTma4eYJa37ZuoQsPw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "simple-wcswidth": "^1.0.1"
+      }
+    },
     "node_modules/copy-anything": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
@@ -3628,6 +3742,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/decompress-response": {
@@ -4235,6 +4359,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -5197,6 +5328,15 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/js-tiktoken": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+      "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5366,6 +5506,56 @@
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.1.11"
+      }
+    },
+    "node_modules/langsmith": {
+      "version": "0.3.72",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.72.tgz",
+      "integrity": "sha512-XjTonMq2fIebzV0BRlPx8mi+Ih/NsQT6W484hrW/pJYuq0aT5kpLtzQthVVmsXH8ZYYkgkbQ5Gh5Mz1qoCrAwg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/uuid": "^10.0.0",
+        "chalk": "^4.1.2",
+        "console-table-printer": "^2.12.1",
+        "p-queue": "^6.6.2",
+        "p-retry": "4",
+        "semver": "^7.6.3",
+        "uuid": "^10.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "*",
+        "@opentelemetry/exporter-trace-otlp-proto": "*",
+        "@opentelemetry/sdk-trace-base": "*",
+        "openai": "*"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/langsmith/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/levn": {
@@ -5818,6 +6008,16 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -5898,6 +6098,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/node-cron/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/node-fetch": {
@@ -6001,6 +6210,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -6031,6 +6250,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/pac-proxy-agent": {
@@ -6198,6 +6461,104 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/pgvector": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/pgvector/-/pgvector-0.2.1.tgz",
+      "integrity": "sha512-nKaQY9wtuiidwLMdVIce1O3kL0d+FxrigCVzsShnoqzOSaWWWOvuctb/sYwlai5cTwwzRSNa+a/NtN2kVZGNJw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -6322,6 +6683,45 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/preact": {
@@ -6652,6 +7052,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/rfdc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
@@ -6980,6 +7390,13 @@
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
+    },
+    "node_modules/simple-wcswidth": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
+      "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
@@ -7645,12 +8062,16 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vfile": {
@@ -8565,6 +8986,15 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -8631,6 +9061,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "license": "ISC",
+      "peer": true,
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@jvddavid/pino-rotating-file": "^1.0.7",
+    "@langchain/textsplitters": "^0.1.0",
     "@tensorflow/tfjs": "^4.22.0",
     "@vitalets/google-translate-api": "^9.2.1",
     "axios": "^1.12.2",
@@ -38,10 +39,13 @@
     "luxon": "^3.7.2",
     "node-cron": "^3.0.3",
     "openai": "^5.23.0",
+    "pg": "^8.12.0",
+    "pgvector": "^0.2.0",
     "pino": "^8.21.0",
     "prom-client": "^15.1.3",
     "puppeteer": "^24.22.2",
     "rss-parser": "^3.13.0",
+    "uuid": "^11.0.3",
     "ws": "^8.18.3"
   },
   "devDependencies": {

--- a/src/db.js
+++ b/src/db.js
@@ -1,0 +1,79 @@
+import pg from "pg";
+import { registerType as registerVectorType } from "pgvector/pg";
+import { CFG, onConfigChange } from "./config.js";
+import { logger, withContext } from "./logger.js";
+
+const { Pool } = pg;
+
+try {
+    registerVectorType(pg);
+} catch (error) {
+    const log = withContext(logger);
+    log.warn({ fn: "db.registerVector", err: error }, "Failed to register pgvector type parser; proceeding without custom handler.");
+}
+
+let pool;
+let activeConnectionString;
+
+const createPool = (connectionString) => {
+    const instance = new Pool({ connectionString });
+    instance.on("error", (error) => {
+        const log = withContext(logger);
+        log.error({ fn: "db.pool", err: error }, "Unexpected error emitted by Postgres pool.");
+    });
+    return instance;
+};
+
+const recyclePool = async () => {
+    if (!pool) {
+        return;
+    }
+
+    const current = pool;
+    pool = undefined;
+    activeConnectionString = undefined;
+    try {
+        await current.end();
+    } catch (error) {
+        const log = withContext(logger);
+        log.warn({ fn: "db.recyclePool", err: error }, "Failed to gracefully close Postgres pool.");
+    }
+};
+
+const ensurePool = async () => {
+    const connectionString = CFG?.rag?.pgUrl;
+    if (!connectionString) {
+        throw new Error("CFG.rag.pgUrl must be configured before issuing database queries.");
+    }
+
+    if (pool && connectionString === activeConnectionString) {
+        return pool;
+    }
+
+    await recyclePool();
+
+    pool = createPool(connectionString);
+    activeConnectionString = connectionString;
+    return pool;
+};
+
+export const query = async (text, params = []) => {
+    const client = await ensurePool();
+    return client.query(text, params);
+};
+
+export const close = async () => {
+    await recyclePool();
+};
+
+onConfigChange((nextConfig) => {
+    const connectionString = nextConfig?.rag?.pgUrl;
+    if (!connectionString) {
+        void recyclePool();
+        return;
+    }
+
+    if (activeConnectionString && connectionString !== activeConnectionString) {
+        void recyclePool();
+    }
+});

--- a/src/vectorStore.js
+++ b/src/vectorStore.js
@@ -1,0 +1,190 @@
+import { toSql } from "pgvector/utils";
+import { v4 as uuidv4 } from "uuid";
+import { CFG } from "./config.js";
+import { query } from "./db.js";
+
+const UPSERT_DOCUMENT_SQL = `
+    INSERT INTO rag_documents (
+        document_id,
+        source,
+        chunk_id,
+        content,
+        metadata,
+        hash,
+        embedding,
+        updated_at
+    )
+    VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, NOW())
+    ON CONFLICT (document_id)
+    DO UPDATE SET
+        source = EXCLUDED.source,
+        chunk_id = EXCLUDED.chunk_id,
+        content = EXCLUDED.content,
+        metadata = EXCLUDED.metadata,
+        hash = EXCLUDED.hash,
+        embedding = EXCLUDED.embedding,
+        updated_at = NOW()
+    RETURNING document_id;
+`.trim();
+
+const DELETE_ALL_BY_SOURCE_SQL = `
+    DELETE FROM rag_documents
+    WHERE source = $1;
+`.trim();
+
+const DELETE_STALE_BY_SOURCE_SQL = `
+    DELETE FROM rag_documents
+    WHERE source = $1
+      AND NOT (document_id = ANY($2::text[]));
+`.trim();
+
+const DEFAULT_SEARCH_LIMIT = 5;
+
+const normalizeEmbedding = (embedding) => {
+    if (!Array.isArray(embedding) || embedding.length === 0) {
+        throw new TypeError("Embedding must be a non-empty array of numbers.");
+    }
+
+    const values = embedding.map((value) => {
+        const parsed = Number(value);
+        if (!Number.isFinite(parsed)) {
+            throw new TypeError("Embedding values must be finite numbers.");
+        }
+        return parsed;
+    });
+
+    return values;
+};
+
+const normalizeOptionalString = (value) => {
+    if (typeof value !== "string") {
+        return null;
+    }
+
+    const trimmed = value.trim();
+    return trimmed === "" ? null : trimmed;
+};
+
+const serializeMetadata = (metadata) => {
+    if (metadata == null) {
+        return "{}";
+    }
+
+    if (typeof metadata === "string") {
+        const trimmed = metadata.trim();
+        return trimmed === "" ? "{}" : trimmed;
+    }
+
+    try {
+        return JSON.stringify(metadata);
+    } catch (error) {
+        return "{}";
+    }
+};
+
+const resolveSearchLimit = (limit) => {
+    const baseLimit = Number.isFinite(limit) ? limit : Number.parseInt(limit ?? "", 10);
+    if (Number.isFinite(baseLimit) && baseLimit > 0) {
+        return baseLimit;
+    }
+
+    const cfgLimit = Number.isFinite(CFG?.rag?.searchLimit)
+        ? CFG.rag.searchLimit
+        : DEFAULT_SEARCH_LIMIT;
+
+    return Number.isFinite(cfgLimit) && cfgLimit > 0 ? cfgLimit : DEFAULT_SEARCH_LIMIT;
+};
+
+export const upsertDocument = async ({
+    documentId = uuidv4(),
+    source,
+    chunkId = null,
+    content = "",
+    metadata = {},
+    hash = null,
+    embedding,
+}) => {
+    const normalizedSource = typeof source === "string" ? source.trim() : "";
+    if (normalizedSource === "") {
+        throw new Error("upsertDocument requires a non-empty source identifier.");
+    }
+
+    const normalizedContent = typeof content === "string" ? content : String(content ?? "");
+    const normalizedChunkId = normalizeOptionalString(chunkId);
+    const normalizedHash = normalizeOptionalString(hash);
+    const serializedMetadata = serializeMetadata(metadata);
+    const vector = toSql(normalizeEmbedding(embedding));
+
+    const result = await query(UPSERT_DOCUMENT_SQL, [
+        documentId,
+        normalizedSource,
+        normalizedChunkId,
+        normalizedContent,
+        serializedMetadata,
+        normalizedHash,
+        vector,
+    ]);
+
+    return result.rows?.[0] ?? null;
+};
+
+export const searchEmbeddings = async ({ embedding, sources = [], limit } = {}) => {
+    const vector = toSql(normalizeEmbedding(embedding));
+    const normalizedSources = Array.isArray(sources)
+        ? sources
+            .map((value) => (typeof value === "string" ? value.trim() : ""))
+            .filter((value) => value !== "")
+        : [];
+
+    const params = [vector];
+    const conditions = [];
+    let nextIndex = 2;
+
+    if (normalizedSources.length > 0) {
+        conditions.push(`source = ANY($${nextIndex}::text[])`);
+        params.push(normalizedSources);
+        nextIndex += 1;
+    }
+
+    const resolvedLimit = resolveSearchLimit(limit);
+    params.push(resolvedLimit);
+
+    const sql = [
+        "SELECT",
+        "    document_id,",
+        "    source,",
+        "    chunk_id,",
+        "    content,",
+        "    metadata,",
+        "    hash,",
+        "    embedding <=> $1 AS distance",
+        "FROM rag_documents",
+        conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "",
+        "ORDER BY embedding <=> $1",
+        `LIMIT $${nextIndex};`,
+    ].filter(Boolean).join("\n");
+
+    const result = await query(sql, params);
+    return result.rows ?? [];
+};
+
+export const deleteStaleDocuments = async (source, keepDocumentIds = []) => {
+    const normalizedSource = typeof source === "string" ? source.trim() : "";
+    if (normalizedSource === "") {
+        throw new Error("deleteStaleDocuments requires a non-empty source identifier.");
+    }
+
+    const normalizedIds = Array.isArray(keepDocumentIds)
+        ? keepDocumentIds
+            .map((value) => (typeof value === "string" ? value.trim() : ""))
+            .filter((value) => value !== "")
+        : [];
+
+    if (normalizedIds.length === 0) {
+        const result = await query(DELETE_ALL_BY_SOURCE_SQL, [normalizedSource]);
+        return result.rowCount ?? 0;
+    }
+
+    const result = await query(DELETE_STALE_BY_SOURCE_SQL, [normalizedSource, normalizedIds]);
+    return result.rowCount ?? 0;
+};

--- a/tests/vectorStore.test.js
+++ b/tests/vectorStore.test.js
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockQuery = vi.fn();
+const mockEnd = vi.fn();
+const mockOn = vi.fn();
+const PoolMock = vi.fn(() => ({
+    query: mockQuery,
+    end: mockEnd,
+    on: mockOn,
+}));
+
+vi.mock("pg", () => ({
+    __esModule: true,
+    default: {
+        Pool: PoolMock,
+        types: {
+            setTypeParser: vi.fn(),
+            builtins: {},
+        },
+    },
+}));
+
+const registerTypeMock = vi.fn();
+vi.mock("pgvector/pg", () => ({
+    registerType: registerTypeMock,
+}));
+
+const toSqlMock = vi.fn();
+vi.mock("pgvector/utils", () => ({
+    toSql: toSqlMock,
+}));
+
+vi.mock("uuid", () => ({
+    v4: vi.fn(() => "uuid-123"),
+}));
+
+const cfg = { rag: { pgUrl: "postgres://localhost/test", searchLimit: 5 } };
+const onConfigChangeMock = vi.fn(() => () => {});
+vi.mock("../src/config.js", () => ({
+    CFG: cfg,
+    onConfigChange: onConfigChangeMock,
+}));
+
+vi.mock("../src/logger.js", () => {
+    const log = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    };
+    return {
+        logger: log,
+        withContext: () => log,
+    };
+});
+
+let upsertDocument;
+let searchEmbeddings;
+
+describe("vectorStore", () => {
+    beforeEach(async () => {
+        vi.resetModules();
+
+        mockQuery.mockReset();
+        mockQuery.mockImplementation(() => Promise.resolve({ rows: [], rowCount: 0 }));
+        mockEnd.mockReset();
+        mockEnd.mockResolvedValue();
+        mockOn.mockReset();
+        PoolMock.mockClear();
+        registerTypeMock.mockClear();
+        toSqlMock.mockReset();
+        toSqlMock.mockReturnValue("vector_literal");
+        onConfigChangeMock.mockClear();
+
+        cfg.rag = { pgUrl: "postgres://localhost/test", searchLimit: 5 };
+
+        ({ upsertDocument, searchEmbeddings } = await import("../src/vectorStore.js"));
+    });
+
+    it("serializes embeddings and issues an upsert query", async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [{ document_id: "uuid-123" }] });
+
+        const result = await upsertDocument({
+            source: "news",
+            chunkId: "chunk-42",
+            content: "Conteúdo analisado",
+            metadata: { language: "pt-BR" },
+            hash: "abc123",
+            embedding: [0.12, 0.34, 0.56],
+        });
+
+        expect(toSqlMock).toHaveBeenCalledWith([0.12, 0.34, 0.56]);
+        expect(mockQuery).toHaveBeenCalledTimes(1);
+
+        const [sql, params] = mockQuery.mock.calls[0];
+        expect(sql).toContain("INSERT INTO rag_documents");
+        expect(sql).toContain("ON CONFLICT (document_id)");
+        expect(params).toEqual([
+            "uuid-123",
+            "news",
+            "chunk-42",
+            "Conteúdo analisado",
+            JSON.stringify({ language: "pt-BR" }),
+            "abc123",
+            "vector_literal",
+        ]);
+        expect(result).toEqual({ document_id: "uuid-123" });
+    });
+
+    it("builds a cosine search query with optional source filters", async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [{ document_id: "doc-1", distance: 0.42 }] });
+
+        const rows = await searchEmbeddings({
+            embedding: [0.1, 0.2],
+            sources: ["news"],
+            limit: 3,
+        });
+
+        expect(toSqlMock).toHaveBeenCalledWith([0.1, 0.2]);
+        expect(mockQuery).toHaveBeenCalledTimes(1);
+
+        const [sql, params] = mockQuery.mock.calls[0];
+        expect(sql).toContain("SELECT");
+        expect(sql).toContain("embedding <=> $1 AS distance");
+        expect(sql).toContain("ORDER BY embedding <=> $1");
+        expect(sql).toContain("WHERE source = ANY($2::text[])");
+        expect(sql).toContain("LIMIT $3;");
+        expect(params).toEqual(["vector_literal", ["news"], 3]);
+        expect(rows).toEqual([{ document_id: "doc-1", distance: 0.42 }]);
+    });
+});


### PR DESCRIPTION
## Summary
- add pg/pgvector, uuid, and text splitter dependencies to enable retrieval-augmented generation pipelines
- extend configuration, documentation, and env templates with rag settings and postgres connection handling
- implement pooled database helper, vector store operations, and vitest coverage validating query generation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e4321e9a488326ba09b7133cb748a5