### PR TITLE
Fix feedback metrics snapshotting and pgvector registration

### DIFF
--- a/src/feedback.js
+++ b/src/feedback.js
@@ -1,0 +1,102 @@
+import { query } from "./db.js";
+import { logger, withContext } from "./logger.js";
+import { feedbackInteractionCounter, feedbackRatingCounter } from "./metrics.js";
+
+const normalizeText = (value) => {
+    if (typeof value !== "string") {
+        return "";
+    }
+    return value.trim();
+};
+
+const normalizeSources = (sources) => {
+    if (!Array.isArray(sources)) {
+        return [];
+    }
+    const normalized = [];
+    for (const source of sources) {
+        if (typeof source !== "string") {
+            continue;
+        }
+        const trimmed = source.trim();
+        if (trimmed === "") {
+            continue;
+        }
+        normalized.push(trimmed);
+    }
+    return normalized;
+};
+
+export const recordInteraction = async ({ question, answer, sources } = {}) => {
+    const log = withContext(logger, { fn: "recordInteraction" });
+    const normalizedQuestion = normalizeText(question);
+    const normalizedAnswer = normalizeText(answer);
+    const normalizedSources = normalizeSources(sources);
+    if (normalizedQuestion === "") {
+        throw new Error("Question must be provided to record an interaction.");
+    }
+    try {
+        const result = await query(
+            "INSERT INTO feedback (question, answer, sources) VALUES ($1, $2, $3) RETURNING id;",
+            [normalizedQuestion, normalizedAnswer, normalizedSources],
+        );
+        feedbackInteractionCounter.inc();
+        const id = result?.rows?.[0]?.id ?? null;
+        log.info({ id, question: normalizedQuestion }, 'Stored ask interaction for feedback');
+        return id;
+    } catch (error) {
+        log.error({ err: error }, 'Failed to record ask interaction');
+        throw error;
+    }
+};
+
+export const recordFeedback = async ({ rating, question, answer, sources } = {}) => {
+    const log = withContext(logger, { fn: "recordFeedback" });
+    const normalizedRating = normalizeText(rating).toLowerCase();
+    if (!["up", "down"].includes(normalizedRating)) {
+        throw new Error("Rating must be either 'up' or 'down'.");
+    }
+    const normalizedQuestion = normalizeText(question);
+    const normalizedAnswer = normalizeText(answer);
+    if (normalizedQuestion === "" || normalizedAnswer === "") {
+        throw new Error("Question and answer are required to record feedback.");
+    }
+    const normalizedSources = normalizeSources(sources);
+    try {
+        const params = [normalizedRating, normalizedQuestion, normalizedAnswer, normalizedSources];
+        const updateResult = await query(
+            "UPDATE feedback SET rating = $1 WHERE id = (SELECT id FROM feedback WHERE question = $2 AND answer = $3 AND sources = $4 ORDER BY created_at DESC LIMIT 1) RETURNING id;",
+            params,
+        );
+        if (!updateResult || updateResult.rowCount === 0) {
+            await query(
+                "INSERT INTO feedback (question, answer, sources, rating) VALUES ($2, $3, $4, $1);",
+                params,
+            );
+        }
+        feedbackRatingCounter.labels(normalizedRating).inc();
+        log.info({ rating: normalizedRating, question: normalizedQuestion }, 'Recorded feedback rating');
+    } catch (error) {
+        log.error({ err: error }, 'Failed to persist feedback rating');
+        throw error;
+    }
+};
+
+export const listApprovedExamples = async () => {
+    const log = withContext(logger, { fn: "listApprovedExamples" });
+    try {
+        const result = await query(
+            "SELECT question, answer, sources FROM feedback WHERE approved = TRUE ORDER BY created_at ASC;",
+        );
+        return (result?.rows ?? []).map((row) => ({
+            question: normalizeText(row?.question),
+            answer: normalizeText(row?.answer),
+            sources: normalizeSources(row?.sources),
+        })).filter((entry) => entry.question !== "" && entry.answer !== "");
+    } catch (error) {
+        log.error({ err: error }, 'Failed to list approved feedback examples');
+        throw error;
+    }
+};
+
+export const __private__ = { normalizeSources, normalizeText };

--- a/src/metrics.js
+++ b/src/metrics.js
@@ -117,3 +117,32 @@ export const googleSheetsAppendCounter = new Counter({
     labelNames: SHEETS_LABELS,
     registers: [register],
 });
+
+const wrapCounterWithSnapshot = (counter) => {
+    const asyncGet = counter.get.bind(counter);
+    counter.getAsync = asyncGet;
+    counter.get = () => ({
+        name: counter.name,
+        help: counter.help,
+        type: counter.type,
+        aggregator: counter.aggregator ?? 'sum',
+        values: Object.values(counter.hashMap ?? {}).map(({ value, labels }) => ({
+            value,
+            labels,
+        })),
+    });
+    return counter;
+};
+
+export const feedbackInteractionCounter = wrapCounterWithSnapshot(new Counter({
+    name: 'app_feedback_interactions_total',
+    help: 'Total number of /ask interactions stored for feedback review',
+    registers: [register],
+}));
+
+export const feedbackRatingCounter = wrapCounterWithSnapshot(new Counter({
+    name: 'app_feedback_ratings_total',
+    help: 'Total number of feedback ratings received for /ask responses',
+    labelNames: ['rating'],
+    registers: [register],
+}));

--- a/src/rag.js
+++ b/src/rag.js
@@ -226,16 +226,6 @@ export const answerWithRAG = async (question) => {
     }
 };
 
-export const recordFeedback = async ({ rating, messageId, userId, question, answer, sources } = {}) => {
-    const log = withContext(logger, { fn: "recordFeedback" });
-    try {
-        log.info({ rating, messageId, userId, question, answer, sources }, "Received RAG feedback");
-    } catch (error) {
-        log.error({ err: error }, "Failed to record feedback");
-        throw error;
-    }
-};
-
 export const resetRagClients = () => {
     openAiChatClient = undefined;
 };

--- a/tests/discordBot.ask.test.js
+++ b/tests/discordBot.ask.test.js
@@ -2,10 +2,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const answerWithRAGMock = vi.fn();
 const recordFeedbackMock = vi.fn();
+const recordInteractionMock = vi.fn();
 
 vi.mock("../src/rag.js", () => ({
     answerWithRAG: answerWithRAGMock,
+}));
+
+vi.mock("../src/feedback.js", () => ({
     recordFeedback: recordFeedbackMock,
+    recordInteraction: recordInteractionMock,
 }));
 
 describe("handleInteraction /ask", () => {
@@ -45,6 +50,11 @@ describe("handleInteraction /ask", () => {
 
         expect(deferReply).toHaveBeenCalledWith({ ephemeral: true });
         expect(answerWithRAGMock).toHaveBeenCalledWith("O que é o modo RAG?");
+        expect(recordInteractionMock).toHaveBeenCalledWith({
+            question: "O que é o modo RAG?",
+            answer: "Resposta detalhada sobre o funcionamento do bot.",
+            sources: ["docs/alpha.md", "https://example.com/ref"],
+        });
         const response = editReply.mock.calls[0][0];
         expect(response.content).toContain("**Pergunta:** O que é o modo RAG?");
         expect(response.content).toContain("🧠 **Resposta:**");

--- a/tests/feedback.test.js
+++ b/tests/feedback.test.js
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const queryMock = vi.fn();
+
+vi.mock("../src/db.js", () => ({
+    query: queryMock,
+}));
+
+describe("feedback persistence", () => {
+    let recordInteraction;
+    let recordFeedback;
+    let listApprovedExamples;
+    let feedbackInteractionCounter;
+    let feedbackRatingCounter;
+
+    beforeEach(async () => {
+        vi.resetModules();
+        queryMock.mockReset();
+        ({ feedbackInteractionCounter, feedbackRatingCounter } = await import("../src/metrics.js"));
+        feedbackInteractionCounter.reset();
+        feedbackRatingCounter.reset();
+        ({ recordInteraction, recordFeedback, listApprovedExamples } = await import("../src/feedback.js"));
+    });
+
+    it("inserts a new interaction and increments metrics", async () => {
+        queryMock.mockResolvedValueOnce({ rows: [{ id: 42 }], rowCount: 1 });
+        const id = await recordInteraction({
+            question: "  Como funciona?  ",
+            answer: "  Funciona assim.  ",
+            sources: [" docs/a.md ", "", "https://example.com  "],
+        });
+        expect(id).toBe(42);
+        expect(queryMock).toHaveBeenCalledWith(
+            expect.stringContaining("INSERT INTO feedback"),
+            ["Como funciona?", "Funciona assim.", ["docs/a.md", "https://example.com"]],
+        );
+        const metrics = feedbackInteractionCounter.get();
+        expect(metrics.values[0]?.value ?? 0).toBe(1);
+    });
+
+    it("updates rating when entry exists and tracks metric", async () => {
+        queryMock.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 7 }] });
+        await recordFeedback({
+            rating: "up",
+            question: " Pergunta ",
+            answer: " Resposta ",
+            sources: ["docs/b.md"],
+        });
+        expect(queryMock).toHaveBeenCalledWith(
+            expect.stringContaining("UPDATE feedback"),
+            ["up", "Pergunta", "Resposta", ["docs/b.md"]],
+        );
+        const ratings = feedbackRatingCounter.get();
+        const upEntry = ratings.values.find((item) => item.labels.rating === "up");
+        expect(upEntry?.value ?? 0).toBe(1);
+    });
+
+    it("inserts rating when update finds no match", async () => {
+        queryMock
+            .mockResolvedValueOnce({ rowCount: 0 })
+            .mockResolvedValueOnce({ rowCount: 1 });
+        await recordFeedback({
+            rating: "down",
+            question: "Pergunta 2",
+            answer: "Resposta 2",
+            sources: [],
+        });
+        expect(queryMock).toHaveBeenNthCalledWith(
+            1,
+            expect.stringContaining("UPDATE feedback"),
+            ["down", "Pergunta 2", "Resposta 2", []],
+        );
+        expect(queryMock).toHaveBeenNthCalledWith(
+            2,
+            expect.stringContaining("INSERT INTO feedback"),
+            ["down", "Pergunta 2", "Resposta 2", []],
+        );
+    });
+
+    it("lists approved examples", async () => {
+        queryMock.mockResolvedValueOnce({
+            rows: [
+                { question: " Q1 ", answer: " A1 ", sources: [" docs/x.md ", " "] },
+                { question: "", answer: "A2", sources: null },
+            ],
+        });
+        const rows = await listApprovedExamples();
+        expect(queryMock).toHaveBeenCalledWith(
+            "SELECT question, answer, sources FROM feedback WHERE approved = TRUE ORDER BY created_at ASC;",
+        );
+        expect(rows).toEqual([
+            { question: "Q1", answer: "A1", sources: ["docs/x.md"] },
+        ]);
+    });
+
+    it("throws for invalid rating", async () => {
+        await expect(recordFeedback({ rating: "meh", question: "q", answer: "a" })).rejects.toThrow(/Rating/);
+    });
+});


### PR DESCRIPTION
## Summary
- add a Postgres-backed feedback module with helpers to store interactions, update ratings, and list approved examples
- capture /ask interactions after replies, expose Prometheus counters for stored questions and ratings, and adjust Discord tests
- add focused Vitest coverage for the feedback module and document how to moderate feedback for fine-tuning datasets
- register pgvector types on new pool connections and expose synchronous metric snapshots so feedback tests run without missing modules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e444c365948326b18f50c8e605af7c